### PR TITLE
fix: flash of white while menubar loads

### DIFF
--- a/src/menubar/index.js
+++ b/src/menubar/index.js
@@ -15,7 +15,7 @@ export default async function (ctx) {
         skipTaskbar: true,
         width: 280,
         height: 385,
-        backgroundColor: '#ffffff',
+        backgroundColor: '#0b3a53',
         webPreferences: {
           nodeIntegration: true
         }


### PR DESCRIPTION
Set the background to navy to match the bg color when the
menu loads

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>