### PR TITLE
fix: menus on macOS

### DIFF
--- a/src/lib/app-menu.js
+++ b/src/lib/app-menu.js
@@ -1,0 +1,91 @@
+const { app, Menu } = require('electron')
+
+const template = [
+  {
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'pasteandmatchstyle' },
+      { role: 'delete' },
+      { role: 'selectall' }
+    ]
+  },
+  {
+    label: 'View',
+    submenu: [
+      { role: 'reload' },
+      { role: 'forcereload' },
+      { role: 'toggledevtools' },
+      { type: 'separator' },
+      { role: 'resetzoom' },
+      { role: 'zoomin' },
+      { role: 'zoomout' },
+      { type: 'separator' },
+      { role: 'togglefullscreen' }
+    ]
+  },
+  {
+    role: 'window',
+    submenu: [
+      { role: 'minimize' },
+      { role: 'close' }
+    ]
+  },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Learn More',
+        click () { require('electron').shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop') }
+      }
+    ]
+  }
+]
+
+if (process.platform === 'darwin') {
+  template.unshift({
+    label: app.getName(),
+    submenu: [
+      { role: 'about' },
+      { type: 'separator' },
+      { role: 'services' },
+      { type: 'separator' },
+      { role: 'hide' },
+      { role: 'hideothers' },
+      { role: 'unhide' },
+      { type: 'separator' },
+      { role: 'quit' }
+    ]
+  })
+
+  // Edit menu
+  template[1].submenu.push(
+    { type: 'separator' },
+    {
+      label: 'Speech',
+      submenu: [
+        { role: 'startspeaking' },
+        { role: 'stopspeaking' }
+      ]
+    }
+  )
+
+  // Window menu
+  template[3].submenu = [
+    { role: 'close' },
+    { role: 'minimize' },
+    { role: 'zoom' },
+    { type: 'separator' },
+    { role: 'front' }
+  ]
+}
+
+export default function () {
+  const menu = Menu.buildFromTemplate(template)
+  Menu.setApplicationMenu(menu)
+}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -6,9 +6,11 @@ import autoLaunch from './auto-launch'
 import downloadHash from './download-hash'
 import ipfsStats from './ipfs-stats'
 import takeScreenshot from './take-screenshot'
+import appMenu from './app-menu'
 
 export default async function () {
   let ctx = {}
+  await appMenu()
   await openExternal(ctx)
   await registerDaemon(ctx) // ctx.ipfsd
   await registerMenubar(ctx) // ctx.sendToMenubar


### PR DESCRIPTION
This adds a menu that should fix #766. To try it, you must run `npm run build` and install the dmg as `npm start` already sets a menu if it doesn't exist.

@olizilla @fsdiogo please try this out to see if it works. Notice that right now we didn't have nothing in the menu for the bundled version. It prevented macOS to allow copy/paste.

I added all the default options that Electron has to the menu. We might want to activate some of them only during development such as Dev Tools

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>