### PR TITLE
[WIP] feat: display peer count in taskbar/cube menu

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -5,6 +5,7 @@
   "ipfsIsNotRunning": "IPFS is Not Running",
   "ipfsHasErrored": "IPFS has Errored",
   "runningWithGC": "Running (GC in progress)",
+  "numberOfPeers": "Foo Peers",
   "start": "Start",
   "stop": "Stop",
   "restart": "Restart",

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -5,7 +5,6 @@
   "ipfsIsNotRunning": "IPFS is Not Running",
   "ipfsHasErrored": "IPFS has Errored",
   "runningWithGC": "Running (GC in progress)",
-  "numberOfPeers": "Foo Peers",
   "start": "Start",
   "stop": "Stop",
   "restart": "Restart",

--- a/src/tray.js
+++ b/src/tray.js
@@ -57,6 +57,11 @@ function buildMenu (ctx) {
       icon: path.resolve(path.join(__dirname, `../assets/icons/status/${color}.png`))
     })),
     {
+      id: 'numberOfPeers',
+      label: i18n.t('numberOfPeers'),
+      enabled: false
+    },
+    {
       id: 'restartIpfs',
       label: i18n.t('restart'),
       click: () => { ctx.restartIpfs() },
@@ -258,7 +263,7 @@ module.exports = function (ctx) {
     menu = buildMenu(ctx)
 
     tray.setContextMenu(menu)
-    tray.setToolTip('IPFS Desktop')
+    tray.setToolTip('Foo Peers')
 
     menu.on('menu-will-show', () => { ipcMain.emit('menubar-will-open') })
     menu.on('menu-will-close', () => { ipcMain.emit('menubar-will-close') })
@@ -276,6 +281,8 @@ module.exports = function (ctx) {
     menu.getMenuItemById('ipfsIsNotRunning').visible = status === STATUS.STOPPING_FINISHED && !gcRunning
     menu.getMenuItemById('ipfsHasErrored').visible = errored && !gcRunning
     menu.getMenuItemById('runningWithGC').visible = gcRunning
+
+    menu.getMenuItemById('numberOfPeers').visible = status === STATUS.STARTING_FINISHED && !gcRunning
 
     menu.getMenuItemById('startIpfs').visible = status === STATUS.STOPPING_FINISHED
     menu.getMenuItemById('stopIpfs').visible = status === STATUS.STARTING_FINISHED

--- a/src/tray.js
+++ b/src/tray.js
@@ -263,7 +263,7 @@ module.exports = function (ctx) {
     menu = buildMenu(ctx)
 
     tray.setContextMenu(menu)
-    tray.setToolTip('Foo Peers')
+    tray.setToolTip('Foo' + ' ' + i18n.t('peers'))
 
     menu.on('menu-will-show', () => { ipcMain.emit('menubar-will-open') })
     menu.on('menu-will-close', () => { ipcMain.emit('menubar-will-close') })

--- a/src/tray.js
+++ b/src/tray.js
@@ -58,7 +58,7 @@ function buildMenu (ctx) {
     })),
     {
       id: 'numberOfPeers',
-      label: i18n.t('numberOfPeers'),
+      label: 'Foo' + ' ' + i18n.t('peers'),
       enabled: false
     },
     {


### PR DESCRIPTION
This PR stubs out the location of a peer count in the taskbar/menubar "cube menu" as discussed in https://github.com/ipfs-shipyard/ipfs-desktop/issues/1312:
- Upon hover on cube icon
- Underneath running status (also disabled/greyed out, only visible when "IPFS is Running")

**Currently isn't connected to actual peer count, just visual PoC.**

Screenshots (macOS):

![image](https://user-images.githubusercontent.com/1507828/89353637-09f7b300-d674-11ea-9c90-54920221e87c.png)

![image](https://user-images.githubusercontent.com/1507828/89353655-1714a200-d674-11ea-9b23-c9e5bbd9737f.png)

Closes https://github.com/ipfs-shipyard/ipfs-desktop/issues/1312