### PR TITLE
fix: print useful error on write fail

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -177,7 +177,7 @@
   },
   "couldNotSaveDialog": {
     "title": "Could not write to disk",
-    "message": "There was an error writing to the disk. Please try again."
+    "message": "There was an error writing to \"{ dir }\": \"{ error }\". Please try again or inspect logs for more details."
   },
   "launchAtLoginNotSupported": {
     "title": "Error",

--- a/src/dialogs/prompt/index.js
+++ b/src/dialogs/prompt/index.js
@@ -48,7 +48,8 @@ module.exports = async function showPrompt (options) {
       ? pallette.dark.background
       : pallette.default.background,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      contextIsolation: false
     },
     ...options.window
   })

--- a/src/download-cid.js
+++ b/src/download-cid.js
@@ -18,8 +18,11 @@ const SHORTCUT = IS_MAC
   : 'CommandOrControl+Alt+D'
 
 async function saveFile (dir, file) {
-  const location = join(dir, file.path)
-  await fs.outputFile(location, file.content)
+  const destination = join(dir, file.path)
+  if (!destination.startsWith(dir)) {
+    throw new Error(`unable to create '${file.path}' outside of '${dir}'`)
+  }
+  await fs.outputFile(destination, file.content)
 }
 
 async function get (ipfs, cid) {
@@ -129,11 +132,12 @@ async function downloadCid (ctx) {
       shell.showItemInFolder(join(dir, files[0].path))
     }
   } catch (err) {
-    logger.error(`[cid download] ${err.toString()}`)
+    const errMsg = err.toString()
+    logger.error(`[cid download] ${errMsg}`)
 
     showDialog({
       title: i18n.t('couldNotSaveDialog.title'),
-      message: i18n.t('couldNotSaveDialog.message'),
+      message: i18n.t('couldNotSaveDialog.message', { dir, error: errMsg }),
       buttons: [i18n.t('close')]
     })
   }


### PR DESCRIPTION
This displays error details when write to a destination directory fails, and ensures stored files are contained within destination dir.
Should improve UX in situations where user picked read-only directory, run out of disk space etc. 

cc @schomatis 