### PR TITLE
fix: snapcraft ci job

### DIFF
--- a/.github/workflows/snapcraft.yml
+++ b/.github/workflows/snapcraft.yml
@@ -1,6 +1,12 @@
 name: snapcraft
 
 on:
+  workflow_dispatch:
+    inputs:
+      manual_name:
+        required: true
+        description: 'Release number to publish (without v prefix)'
+        default: '0.0.0'
   release:
     types: [published]
 
@@ -10,15 +16,15 @@ jobs:
 
     steps:
       - name: Download .snap artifact
-        uses: dsaltares/fetch-gh-release-asset@aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c # 0.0.5
+        uses: dsaltares/fetch-gh-release-asset@0efe227dedb360b09ea0e533795d584b61c461a9 # 0.06
         with:
           repo: ipfs-shipyard/ipfs-desktop
-          version: tags/${{ github.event.release.tag_name }}
-          file: ipfs-desktop-${{ github.event.release.name }}-linux-amd64.snap
+          version: tags/v${{ github.event.inputs.manual_name || github.event.release.name }}
+          file: ipfs-desktop-${{ github.event.inputs.manual_name || github.event.release.name }}-linux-amd64.snap
 
       - name: Publish to Snapcraft
         uses: snapcore/action-publish@f1879414dc5500e02a36f3d715bca6ddd438c913 # 1.0.2
         with:
           store_login: ${{ secrets.SNAP_STORE_LOGIN }}
-          snap: ipfs-desktop-${{ github.event.release.name }}-linux-amd64.snap
+          snap: ipfs-desktop-${{ github.event.inputs.manual_name || github.event.release.name }}-linux-amd64.snap
           release: stable


### PR DESCRIPTION
This PR aims to fix publishing to https://snapcraft.io/ipfs-desktop + add ability to trigger job manually.