### PR TITLE
fix: go-ipfs 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4695,9 +4695,9 @@
       }
     },
     "go-ipfs": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.9.0.tgz",
-      "integrity": "sha512-qJvQJwm6SRHnI9X3YU8l52YNmY6+EYdJxtgb8w9RB8LFyhk/Q7kxvkpogCcmZZxj/60xEfQe1y/FE9vPgNfMqw==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.9.1.tgz",
+      "integrity": "sha512-69sDGENU7xEPDNytEzE+swKTNSLr+OJEfdEYQ41m91dzNyHyxABB4Rteg4uzsj34lTizjVI1m7Gld3g5Dgf6Ag==",
       "requires": {
         "cachedir": "^2.3.0",
         "go-platform": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "electron-updater": "4.3.9",
     "fix-path": "^3.0.0",
     "fs-extra": "^9.1.0",
-    "go-ipfs": "0.9.0",
+    "go-ipfs": "0.9.1",
     "i18next": "^20.2.1",
     "i18next-electron-language-detector": "0.0.10",
     "i18next-icu": "^2.0.3",


### PR DESCRIPTION
RELEASE NOTES: https://github.com/ipfs/go-ipfs/releases/tag/v0.9.1

Closes https://github.com/ipfs/ipfs-desktop/issues/1872