### PR TITLE
fix: use context bridge

### DIFF
--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -29,7 +29,6 @@ const createWindow = () => {
     webPreferences: {
       preload: join(__dirname, 'preload.js'),
       webSecurity: false,
-      contextIsolation: false,
       allowRunningInsecureContent: false,
       enableRemoteModule: process.env.NODE_ENV === 'test', // https://github.com/electron-userland/spectron/pull/738#issuecomment-754810364
       nodeIntegration: process.env.NODE_ENV === 'test'

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -29,6 +29,7 @@ const createWindow = () => {
     webPreferences: {
       preload: join(__dirname, 'preload.js'),
       webSecurity: false,
+      contextIsolation: false,
       allowRunningInsecureContent: false,
       enableRemoteModule: process.env.NODE_ENV === 'test', // https://github.com/electron-userland/spectron/pull/738#issuecomment-754810364
       nodeIntegration: process.env.NODE_ENV === 'test'

--- a/src/webui/preload.js
+++ b/src/webui/preload.js
@@ -1,8 +1,7 @@
-const { ipcRenderer } = require('electron')
+const { ipcRenderer, contextBridge } = require('electron')
 const screenshotHook = require('./screenshot')
 const connectionHook = require('./connection-status')
 const { COUNTLY_KEY, VERSION } = require('../common/consts')
-const { contextBridge } = require('electron')
 
 screenshotHook()
 connectionHook()


### PR DESCRIPTION
Electron 12 introduced context isolation enabled by default. Thus, the `window` object that the preload script and the Web UI page have access to are different. Hence, Web UI cannot detect if it's running inside Desktop. ~Disabling Context Isolation fixes the issue.~ Using the new `contextBridge` function fixes the issue, as well as exposing the language update function through the global object.
	  
## How can you see it is not working properly in the current version?
	  
Open Settings, go to the Analytics part and check the events list. If you don't see `SCREENSHOT_TAKEN` (among others) is because of this.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>