### PR TITLE
chore: default --agent-version-suffix and --routing

### DIFF
--- a/src/common/store.js
+++ b/src/common/store.js
@@ -6,9 +6,10 @@ const defaults = {
     type: 'go',
     path: '',
     flags: [
+      '--agent-version-suffix=desktop',
       '--migrate',
       '--enable-gc',
-      '--routing', 'dhtclient'
+      '--routing=dhtclient'
     ]
   },
   language: (electron.app || electron.remote.app).getLocale(),
@@ -31,6 +32,25 @@ const migrations = {
     // ensure checkbox follows cli flag config
     if (flags.includes('--enable-gc') && !automaticGC) {
       store.set('automaticGC', true)
+    }
+  },
+  '>=0.17.0': store => {
+    let flags = store.get('ipfsConfig.flags', [])
+
+    // make sure version suffix is always present and normalized
+    const setVersionSuffix = '--agent-version-suffix=desktop'
+    if (!flags.includes(setVersionSuffix)) {
+      // remove any custom suffixes, if present
+      flags = flags.filter(f => !f.startsWith('--agent-version-suffix='))
+      // set /desktop
+      flags.push('--agent-version-suffix=desktop')
+      store.set('ipfsConfig.flags', flags)
+    }
+    // merge routing flags into one
+    if (flags.includes('--routing') && flags.includes('dhtclient')) {
+      flags = flags.filter(f => f !== '--routing').filter(f => f !== 'dhtclient')
+      flags.push('--routing=dhtclient')
+      store.set('ipfsConfig.flags', flags)
     }
   }
 }


### PR DESCRIPTION
[go-ipfs 0.10.0 shipped](https://github.com/ipfs/go-ipfs/releases/tag/v0.10.0) with support for running  `ipfs daemon` with custom `--agent-version-suffix`  (https://github.com/ipfs/go-ipfs/pull/8419)

This PR adds `--agent-version-suffix=desktop` and cleans up the way we set `--routing`
IPFS Desktop nodes will now announce themselves as `go-ipfs/0.10.0/desktop`