### PR TITLE
proof of concept: close Web UI window instead of hiding 

### DIFF
--- a/src/second-instance.js
+++ b/src/second-instance.js
@@ -12,6 +12,6 @@ module.exports = async function (ctx) {
       return
     }
 
-    ctx.launchWebUI()
+    await ctx.launchWebUI()
   })
 }

--- a/src/take-screenshot.js
+++ b/src/take-screenshot.js
@@ -99,9 +99,11 @@ function handleScreenshot (ctx) {
   }
 }
 
-function takeScreenshot (ctx) {
-  const { webui } = ctx
+async function takeScreenshot (ctx) {
+  const { getWebUI } = ctx
   logger.info('[screenshot] taking screenshot')
+
+  const webui = await getWebUI()
   webui.webContents.send('screenshot')
 }
 


### PR DESCRIPTION
This is a proof of concept for #1893. In this PR, the Web UI window is only created on demand, i.e., when we launch some URL on the Web UI or if the user explicitly set `openWebUIAtLaunch` to `true`. When the window is closed, it is actually closed and not hidden.

Electron runs 4 processes: Electron, Electron Helper, Electron Helper (GPU) and Electron Helper (Renderer). Only the renderer process is killed by the window closing. The GPU process is still on.

Problems with this approach:
- OSes that do not have a menubar functionality cannot close IFPS Desktop.

@lidel what do you think?