### PR TITLE
fix: remove zip for Squirrel.Mac

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -22,6 +22,7 @@ mac:
   gatekeeperAssess: false
   entitlements: './pkgs/macos/entitlements.mac.plist'
   entitlementsInherit: './pkgs/macos/entitlements.mac.plist'
+  target: 'dmg'
 
 dmg:
   iconSize: 160


### PR DESCRIPTION
Removing `zip` to fix UX issue where users are confused by "broken zip installer".

See rationale: https://github.com/ipfs/ipfs-desktop/issues/1922#issuecomment-980034904

Closes #1922