### PR TITLE
fix: add .manualCheckForUpdates before tray startup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,9 +70,9 @@ async function run () {
     await setupAppMenu(ctx)
 
     await setupWebUI(ctx) // ctx.webui, launchWebUI
+    await setupAutoUpdater(ctx) // ctx.manualCheckForUpdates
     await setupTray(ctx) // ctx.tray
     await setupDaemon(ctx) // ctx.getIpfsd, startIpfs, stopIpfs, restartIpfs
-    await setupAutoUpdater(ctx) // ctx.manualCheckForUpdates
 
     await Promise.all([
       setupArgvFilesHandler(ctx),


### PR DESCRIPTION
Fixes #1927 by ensuring that the context has `.manualCheckForUpdates` before the tray is started.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>