### PR TITLE
feat: better handling of 'unresponsive' event

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -232,5 +232,9 @@
   "clearCustomIpfsBinarySuccess": {
     "title": "Clear custom IPFS binary",
     "message": "The custom IPFS binary was cleared. To start using the bundled IPFS version, IPFS needs to be restarted first."
+  },
+  "unresponsiveWindowDialog": {
+    "title": "IPFS Desktop became unresponsive",
+    "message": "Do you wish to forcefully reload the app?"
   }
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -235,6 +235,8 @@
   },
   "unresponsiveWindowDialog": {
     "title": "IPFS Desktop became unresponsive",
-    "message": "Do you wish to forcefully reload the app?"
+    "message": "Ongoing operation is taking more resources than expected. Do you wish to abort, and forcefully reload the interface?",
+    "forceReload": "Yes, reload",
+    "doNothing": "Do nothing"
   }
 }

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -45,6 +45,8 @@ const createWindow = () => {
   })
 
   window.webContents.on('unresponsive', async () => {
+    logger.error('[web ui] the webui became unresponsive')
+
     const opt = showDialog({
       title: i18n.t('unresponsiveWindowDialog.title'),
       message: i18n.t('unresponsiveWindowDialog.message'),

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -38,8 +38,8 @@ const createWindow = () => {
     window.webContents.openDevTools()
   }
 
-  window.webContents.on('crashed', event => {
-    logger.error(`[web ui] crashed: ${event.toString()}`)
+  window.webContents.on('render-process-gone', (_, { reason, exitCode }) => {
+    logger.error(`[web ui] crashed: ${reason}, code: ${exitCode}`)
   })
 
   window.webContents.on('unresponsive', event => {

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -42,8 +42,8 @@ const createWindow = () => {
     logger.error(`[web ui] crashed: ${reason}, code: ${exitCode}`)
   })
 
-  window.webContents.on('unresponsive', event => {
-    logger.error(`[web ui] unresponsive: ${event.toString()}`)
+  window.webContents.on('unresponsive', () => {
+    logger.error('[web ui] the webui became unresponsive')
   })
 
   window.on('resize', () => {

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -51,8 +51,8 @@ const createWindow = () => {
       title: i18n.t('unresponsiveWindowDialog.title'),
       message: i18n.t('unresponsiveWindowDialog.message'),
       buttons: [
-        i18n.t('ok'),
-        i18n.t('cancel')
+        i18n.t('unresponsiveWindowDialog.forceReload'),
+        i18n.t('unresponsiveWindowDialog.doNothing')
       ]
     })
 

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -39,7 +39,7 @@ const createWindow = () => {
   }
 
   window.webContents.on('render-process-gone', (_, { reason, exitCode }) => {
-    logger.error(`[web ui] crashed: ${reason}, code: ${exitCode}`)
+    logger.error(`[web ui] render-process-gone: ${reason}, code: ${exitCode}`)
   })
 
   window.webContents.on('unresponsive', () => {

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -3,12 +3,14 @@ const { join } = require('path')
 const { URL } = require('url')
 const serve = require('electron-serve')
 const os = require('os')
+const i18n = require('i18next')
 const openExternal = require('./open-external')
 const logger = require('../common/logger')
 const store = require('../common/store')
 const dock = require('../utils/dock')
 const { VERSION, ELECTRON_VERSION } = require('../common/consts')
 const createToggler = require('../utils/create-toggler')
+const { showDialog } = require('../dialogs')
 
 serve({ scheme: 'webui', directory: join(__dirname, '../../assets/webui') })
 
@@ -42,8 +44,20 @@ const createWindow = () => {
     logger.error(`[web ui] render-process-gone: ${reason}, code: ${exitCode}`)
   })
 
-  window.webContents.on('unresponsive', () => {
-    logger.error('[web ui] the webui became unresponsive')
+  window.webContents.on('unresponsive', async () => {
+    const opt = showDialog({
+      title: i18n.t('unresponsiveWindowDialog.title'),
+      message: i18n.t('unresponsiveWindowDialog.message'),
+      buttons: [
+        i18n.t('ok'),
+        i18n.t('cancel')
+      ]
+    })
+
+    if (opt === 0) {
+      window.webContents.forcefullyCrashRenderer()
+      window.webContents.reload()
+    }
   })
 
   window.on('resize', () => {


### PR DESCRIPTION
Replaces the deprecated event 'crashed' by 'render-process-gone' and actually use the information correctly. In addition, I removed the `event.toString()` from the 'unresponsive' event because it does not contain additional info.

References:
- https://github.com/electron/electron/pull/23096
- https://www.electronjs.org/docs/latest/api/web-contents#event-unresponsive
- https://www.electronjs.org/docs/latest/api/web-contents#event-render-process-gone

Noticed this because on [#1951](https://github.com/ipfs/ipfs-webui/issues/1887), the logs just say `[object Object]`...

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>