### PR TITLE
fix: electron version constant

### DIFF
--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -6,7 +6,7 @@ module.exports = Object.freeze({
   IS_WIN: os.platform() === 'win32',
   IS_APPIMAGE: typeof process.env.APPIMAGE !== 'undefined',
   VERSION: packageJson.version,
-  ELECTRON_VERSION: packageJson.devDependencies.electron,
+  ELECTRON_VERSION: process.versions.electron,
   GO_IPFS_VERSION: packageJson.dependencies['go-ipfs'],
   COUNTLY_KEY: process.env.NODE_ENV === 'development'
     ? '6b00e04fa5370b1ce361d2f24a09c74254eee382'


### PR DESCRIPTION
Electron is a dev dependency. However, `devDependencies` is not available after packaging the app and it will throw an error right after starting IPFS Desktop.

The most fail proof way to obtain it is via `process.versions.electron`: https://www.electronjs.org/docs/latest/api/process#processversionselectron-readonly.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>