### PR TITLE
fix: gui error report title

### DIFF
--- a/src/dialogs/errors.js
+++ b/src/dialogs/errors.js
@@ -3,7 +3,13 @@ const path = require('path')
 const i18n = require('i18next')
 const dialog = require('./dialog')
 
-const issueTemplate = (e) => `Please describe what you were doing when this error happened.
+const issueTitle = (e) => {
+  const es = e.stack ? e.stack.toString() : 'unknown error, no stacktrace'
+  const firstLine = es.substr(0, Math.min(es.indexOf('\n'), 72))
+  return `[gui error report] ${firstLine}`
+}
+
+const issueTemplate = (e) => `👉️ Please describe what you were doing when this error happened.
 
 **Specifications**
 
@@ -21,7 +27,7 @@ ${e.stack}
 
 let hasErrored = false
 
-const generateErrorIssueUrl = (e) => `https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?labels=need%2Ftriage&template=bug_report.md&title=[gui%20error%20report]&body=${encodeURI(issueTemplate(e))}`.substring(0, 1999)
+const generateErrorIssueUrl = (e) => `https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?labels=kind%2Fbug%2C+need%2Ftriage&template=bug_report.md&title=${encodeURI(issueTitle(e))}&body=${encodeURI(issueTemplate(e))}`.substring(0, 1999)
 
 function criticalErrorDialog (e) {
   if (hasErrored) return


### PR DESCRIPTION
This PR makes issues created by users from the error dialog more useful  by setting the title to the very first like in the stack trace, which usually includes a useful error message.
