### PR TITLE
fix: ux of notification after file import

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -106,11 +106,11 @@
   },
   "itemsAddedNotification": {
     "title": "Items added",
-    "message": "{ count } items added to your node. A shareable link was copied to your clipboard. Click here to see your files."
+    "message": "{ count } items added to your IPFS node. A shareable link was copied to your clipboard."
   },
   "itemAddedNotification": {
     "title": "Item added",
-    "message": "Item added to your node. A shareable link was copied to your clipboard. Click here to see your file."
+    "message": "Item added to your IPFS node. A shareable link was copied to your clipboard."
   },
   "itemsFailedNotification": {
     "title": "Failed to add items",


### PR DESCRIPTION
Closes #1999 by removing "click here" prompt. 
This way there is no explicit expectation that clicking should do anything.