### PR TITLE
chore: test with macos-10.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, macos-10.15, ubuntu-latest, windows-latest]
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
Quick check if CI tests will pass with `macos-10.15` image