### PR TITLE
fix: static message when ipfs daemon dies on start

### DIFF
--- a/src/daemon/daemon.js
+++ b/src/daemon/daemon.js
@@ -151,6 +151,9 @@ async function startIpfsWithLogs (ipfsd) {
     // that failed to start, allowing user to self-diagnose or report issue.
     isErrored = isErrored || isSpawnedDaemonDead(ipfsd)
     if (isErrored) { // save daemon output to error.log
+      if (logs.trim().length === 0) {
+        logs = 'ipfs daemon failed to start and produced no output (see error.log for details)'
+      }
       logger.error(logs)
       if (migrationPrompt) {
         migrationPrompt.loadWindow(logs, isErrored, isFinished)


### PR DESCRIPTION
This improves UX and error reporting in cases like https://github.com/ipfs/ipfs-desktop/issues/2038