### PR TITLE
Remove hardcoded DHT client routing

### DIFF
--- a/src/common/store.js
+++ b/src/common/store.js
@@ -51,6 +51,16 @@ const migrations = {
       flags.push('--routing=dhtclient')
       store.set('ipfsConfig.flags', flags)
     }
+  },
+  '>=0.20.6': store => {
+    let flags = store.get('ipfsConfig.flags', [])
+
+    // use default instead of hard-coded dhtclient
+    const dhtClientFlag = '--routing=dhtclient'
+    if (flags.includes(dhtClientFlag)) {
+      flags = flags.filter(f => f !== dhtClientFlag)
+      store.set('ipfsConfig.flags', flags)
+    }
   }
 }
 

--- a/src/common/store.js
+++ b/src/common/store.js
@@ -8,8 +8,7 @@ const defaults = {
     flags: [
       '--agent-version-suffix=desktop',
       '--migrate',
-      '--enable-gc',
-      '--routing=dhtclient'
+      '--enable-gc'
     ]
   },
   language: (electron.app || electron.remote.app).getLocale(),


### PR DESCRIPTION
Closes #1859

This PR removes the hard-coded dht client mode and instead relies on go-ipfs' defaults which test for the node's dialability and if so switch the DHT to server mode automatically.

A migration was added to remove the hard-coded routing configration from the users config.json.
