### PR TITLE
chore: remove unused auto-project triggers

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -2,11 +2,9 @@ name: Auto Assign to IPFS-GUI Project
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened]
   pull_request:
-    types: [opened, labeled]
-  issue_comment:
-    types: [created]
+    types: [opened]
 env:
   MY_GITHUB_TOKEN: ${{ secrets.AUTO_PROJECT_PAT }}
 
@@ -17,7 +15,6 @@ jobs:
     steps:
     - name: Assign NEW issues and NEW pull requests to the IPFS-GUI project
       uses: srggrs/assign-one-project-github-action@65a8ddab497df42ef268001e67bbf976f8fd39e1
-      if: github.event.action == 'opened'
       with:
         project: 'https://github.com/orgs/ipfs/projects/17'
         # column_name: 'Intake' # default is 'To do' for issues and 'In progress' for PRs


### PR DESCRIPTION
By doing this we avoid starting the workflow in cases where we don't want to do any real work anyway.