### PR TITLE
chore: use official github action in auto-project

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -2,11 +2,9 @@ name: Auto Assign to IPFS-GUI Project
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened]
   pull_request:
-    types: [opened, labeled]
-  issue_comment:
-    types: [created]
+    types: [opened]
 env:
   MY_GITHUB_TOKEN: ${{ secrets.AUTO_PROJECT_PAT }}
 
@@ -17,7 +15,6 @@ jobs:
     steps:
     - name: Assign NEW issues and NEW pull requests to the IPFS-GUI project
       uses: srggrs/assign-one-project-github-action@65a8ddab497df42ef268001e67bbf976f8fd39e1
-      if: github.event.action == 'opened'
       with:
         project: 'https://github.com/orgs/ipfs/projects/17'
         # column_name: 'Intake' # default is 'To do' for issues and 'In progress' for PRs

--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -5,8 +5,6 @@ on:
     types: [opened]
   pull_request:
     types: [opened]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.AUTO_PROJECT_PAT }}
 
 jobs:
   assign_one_project:
@@ -14,7 +12,7 @@ jobs:
     name: Assign to IPFS-GUI Project
     steps:
     - name: Assign NEW issues and NEW pull requests to the IPFS-GUI project
-      uses: srggrs/assign-one-project-github-action@65a8ddab497df42ef268001e67bbf976f8fd39e1
+      uses: actions/add-to-project@v0.1
       with:
-        project: 'https://github.com/orgs/ipfs/projects/17'
-        # column_name: 'Intake' # default is 'To do' for issues and 'In progress' for PRs
+        project-url: 'https://github.com/orgs/ipfs/projects/17'
+        github-token: ${{ secrets.AUTO_PROJECT_PAT }}

--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -12,7 +12,7 @@ jobs:
     name: Assign to IPFS-GUI Project
     steps:
     - name: Assign NEW issues and NEW pull requests to the IPFS-GUI project
-      uses: actions/add-to-project@v0.1
+      uses: actions/add-to-project@v0.1.0
       with:
         project-url: 'https://github.com/orgs/ipfs/projects/17'
         github-token: ${{ secrets.AUTO_PROJECT_PAT }}


### PR DESCRIPTION
Don't know if you saw this one - there's an action for adding to project which is maintained by GitHub - https://github.com/actions/add-to-project. In general, I think it's a safe default to use GitHub's things when they're good enough. Feel free to close if you want some of those extra features that the other action comes with.

disclaimer: not tested - just wanted to draw your attention to this