### PR TITLE
fix: quit if repository is part of private network

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -210,5 +210,9 @@
   "invalidRepositoryDialog": {
     "title": "Invalid IPFS Repository or Configuration File",
     "message": "The repository at “{ path }” is invalid. The “config” file must be a valid JSON.\n\nBefore starting IPFS Desktop again, please fix the configuration file or rename the old repository to “.ipfs.backup”."
+  },
+  "privateNetworkDialog": {
+    "title": "Private Network IPFS Repository",
+    "message": "The repository at “{ path }” is part of a private network, which is not supported by IPFS Desktop."
   }
 }

--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -372,6 +372,28 @@ function checkValidConfig (ipfsd) {
   }
 }
 
+function checkPublicNetwork (ipfsd) {
+  const swarmKeyPath = join(ipfsd.path, 'swarm.key')
+  const swarmKeyExists = fs.pathExistsSync(swarmKeyPath)
+
+  if (!swarmKeyExists) {
+    return true
+  }
+
+  // Hide other windows so the user focus in on the dialog
+  BrowserWindow.getAllWindows().forEach(w => w.hide())
+
+  // Show blocking dialog
+  showDialog({
+    title: i18n.t('privateNetworkDialog.title'),
+    message: i18n.t('privateNetworkDialog.message', { path: ipfsd.path }),
+    buttons: [i18n.t('quit')]
+  })
+
+  // Only option is to quit
+  app.quit()
+}
+
 module.exports = Object.freeze({
   configPath,
   configExists,
@@ -380,5 +402,6 @@ module.exports = Object.freeze({
   applyDefaults,
   migrateConfig,
   checkPorts,
-  checkValidConfig
+  checkValidConfig,
+  checkPublicNetwork
 })

--- a/src/daemon/daemon.js
+++ b/src/daemon/daemon.js
@@ -3,7 +3,7 @@ const i18n = require('i18next')
 const { showDialog } = require('../dialogs')
 const logger = require('../common/logger')
 const { getCustomBinary } = require('../custom-ipfs-binary')
-const { applyDefaults, migrateConfig, checkPorts, configExists, checkValidConfig, rmApiFile, apiFileExists } = require('./config')
+const { applyDefaults, migrateConfig, checkPorts, configExists, checkValidConfig, checkPublicNetwork, rmApiFile, apiFileExists } = require('./config')
 const showMigrationPrompt = require('./migration-prompt')
 
 function cannotConnectDialog (addr) {
@@ -42,6 +42,10 @@ async function spawn ({ flags, path }) {
 
   if (!checkValidConfig(ipfsd)) {
     throw new Error(`repository at ${ipfsd.path} is invalid`)
+  }
+
+  if (!checkPublicNetwork(ipfsd)) {
+    throw new Error(`repository at ${ipfsd.path} is part of private network`)
   }
 
   if (configExists(ipfsd)) {


### PR DESCRIPTION
Closes #2221 by not letting users use IPFS Desktop with a private network IPFS node, as discussed in yesterday's triage meeting. IPFS Desktop is built with public networks in mind.

![image](https://user-images.githubusercontent.com/5447088/183648161-037bc1d1-1d05-4605-880d-0295910d6aa4.png)
