### PR TITLE
fix: log correct error on spawn

### DIFF
--- a/src/daemon/daemon.js
+++ b/src/daemon/daemon.js
@@ -184,7 +184,7 @@ module.exports = async function (opts) {
     ipfsd = res.ipfsd
     isRemote = res.isRemote
   } catch (err) {
-    return { err: err.toString() }
+    return { err }
   }
 
   if (!isRemote) {


### PR DESCRIPTION
Correctly logs the errors that happen on spawn. Right now, users get a log like `start daemon undefined` because the logger assumes it receives an error, while we sent a string in the case below.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>