### PR TITLE
chore(maintenance): remove addedApiPort after go-ipfs 0.13

### DIFF
--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -58,7 +58,6 @@ function applyDefaults (ipfsd) {
   writeConfigFile(ipfsd, config)
 }
 
-const getRpcApiPort = (config) => getHttpPort(config.Addresses.API)
 const getGatewayPort = (config) => getHttpPort(config.Addresses.Gateway)
 function getHttpPort (addrs) {
   let httpUrl = null
@@ -120,11 +119,7 @@ function migrateConfig (ipfsd) {
     const addedWebUI = addURL('https://webui.ipfs.io')
     const addedGw = addURL(`http://webui.ipfs.io.ipns.localhost:${getGatewayPort(config)}`)
 
-    // https://github.com/ipfs/ipfs-companion/issues/1068 in go-ipfs <0.13
-    // TODO: remove addedApiPort after go-ipfs 0.13 ships
-    const addedApiPort = addURL(`http://127.0.0.1:${getRpcApiPort(config)}`)
-
-    if (addedWebUI || addedGw || addedApiPort) {
+    if (addedWebUI || addedGw) {
       httpHeaders['Access-Control-Allow-Origin'] = accessControlAllowOrigin
       api.HTTPHeaders = httpHeaders
       config.API = api

--- a/test/e2e/launch.e2e.test.js
+++ b/test/e2e/launch.e2e.test.js
@@ -123,8 +123,7 @@ test.describe.serial('Application launch', async () => {
     expect(config.API.HTTPHeaders['Access-Control-Allow-Origin']).toEqual([
       'https://127.0.0.1:4040',
       'https://webui.ipfs.io',
-      'http://webui.ipfs.io.ipns.localhost:0', // ipfsd 'test' profile uses '/ip4/127.0.0.1/tcp/0'
-      'http://127.0.0.1:0' // // ipfsd 'test' profile uses '/ip4/127.0.0.1/tcp/0'
+      'http://webui.ipfs.io.ipns.localhost:0' // ipfsd 'test' profile uses '/ip4/127.0.0.1/tcp/0'
     ])
   })
 
@@ -144,8 +143,7 @@ test.describe.serial('Application launch', async () => {
     // ensure app has migrated config
     expect(config.API.HTTPHeaders['Access-Control-Allow-Origin']).toEqual([
       'https://webui.ipfs.io',
-      'http://webui.ipfs.io.ipns.localhost:0', // ipfsd 'test' profile uses '/ip4/127.0.0.1/tcp/0'
-      'http://127.0.0.1:0' // // ipfsd 'test' profile uses '/ip4/127.0.0.1/tcp/0'
+      'http://webui.ipfs.io.ipns.localhost:0' // ipfsd 'test' profile uses '/ip4/127.0.0.1/tcp/0'
     ])
   })
 
@@ -165,8 +163,7 @@ test.describe.serial('Application launch', async () => {
     // ensure app has migrated config
     expect(config.API.HTTPHeaders['Access-Control-Allow-Origin']).toEqual([
       'https://webui.ipfs.io',
-      'http://webui.ipfs.io.ipns.localhost:0', // ipfsd 'test' profile uses '/ip4/127.0.0.1/tcp/0'
-      'http://127.0.0.1:0' // // ipfsd 'test' profile uses '/ip4/127.0.0.1/tcp/0'
+      'http://webui.ipfs.io.ipns.localhost:0' // ipfsd 'test' profile uses '/ip4/127.0.0.1/tcp/0'
     ])
   })
 


### PR DESCRIPTION
Remove patch for go-ipfs < 0.13.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>