### PR TITLE
fix: ensure .Swarm.ConnMgr exists before accessing

### DIFF
--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -205,19 +205,21 @@ function migrateConfig (ipfsd) {
   }
 
   if (CURRENT_REVISION < 4) {
-    // lower ConnMgr https://github.com/ipfs/ipfs-desktop/issues/2039
-    const { GracePeriod, LowWater, HighWater } = config.Swarm.ConnMgr
-    if (GracePeriod === '300s') {
-      config.Swarm.ConnMgr.GracePeriod = '1m'
-      changed = true
-    }
-    if (LowWater > 20) {
-      config.Swarm.ConnMgr.LowWater = 20
-      changed = true
-    }
-    if (HighWater > 40) {
-      config.Swarm.ConnMgr.HighWater = 40
-      changed = true
+    if (config.Swarm && config.Swarm.ConnMgr) {
+      // lower ConnMgr https://github.com/ipfs/ipfs-desktop/issues/2039
+      const { GracePeriod, LowWater, HighWater } = config.Swarm.ConnMgr
+      if (GracePeriod === '300s') {
+        config.Swarm.ConnMgr.GracePeriod = '1m'
+        changed = true
+      }
+      if (LowWater > 20) {
+        config.Swarm.ConnMgr.LowWater = 20
+        changed = true
+      }
+      if (HighWater > 40) {
+        config.Swarm.ConnMgr.HighWater = 40
+        changed = true
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #2254 by adding a simple check to make sure `.Swarm.ConnMgr` actually exists in the configuration before changing it.

I thought about adding a test case for this, but then I would also have to add one for all the remaining migrations. However, I think that would almost duplicate the E2E time testing.