### PR TITLE
feat: include platform version in error report

### DIFF
--- a/src/dialogs/errors.js
+++ b/src/dialogs/errors.js
@@ -1,5 +1,6 @@
 const { app, shell } = require('electron')
 const path = require('path')
+const os = require('os')
 const i18n = require('i18next')
 const dialog = require('./dialog')
 
@@ -13,7 +14,7 @@ const issueTemplate = (e) => `👉️ Please describe what you were doing when t
 
 **Specifications**
 
-- **OS**: ${process.platform}
+- **OS**: ${os.platform()} ${os.release()}
 - **IPFS Desktop Version**: ${app.getVersion()}
 - **Electron Version**: ${process.versions.electron}
 - **Chrome Version**: ${process.versions.chrome}


### PR DESCRIPTION
Sometimes we need to know the user's platform (OS) version and not just which OS it is. This PR adds the [`os.release()`](https://nodejs.org/api/os.html#osrelease) to give us that information. Please note that this releases might not be 1:1 connected with the commercial names of the OSes. For macOS, for example, version 12.5, we get a kernel version of 21.6.0.

The other option, with more information, would be to print [`os.version()`](https://nodejs.org/api/os.html#osversion), which provides even more information:

```node
> os.release()
'21.6.0'
> os.platform()
'darwin'
> os.version()
'Darwin Kernel Version 21.6.0: Wed Aug 10 14:28:23 PDT 2022; root:xnu-8020.141.5~2/RELEASE_ARM64_T6000'
```

I personally think `os.version()` would be better and more informative, but it is not as succinct. What do you think @lidel @SgtPooki?