### PR TITLE
Add Valist GitHub Action to release flow

### DIFF
--- a/.github/workflows/valist.yml
+++ b/.github/workflows/valist.yml
@@ -1,0 +1,30 @@
+name: Valist Publish
+on:
+  release:
+    types: [published]
+jobs:
+  valist-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: robinraju/release-downloader@v1.4
+        with:
+          repository: "ipfs/ipfs-desktop"
+          latest: true
+          tarBall: true
+          zipBall: true
+          fileName: "*"
+      - uses: valist-io/valist-github-action@v2.5.6
+        env:
+          RELEASE_NAME: ${{ github.event.release.name }}
+        with:
+          private-key: ${{ secrets.VALIST_SIGNER }}
+          account: ipfs
+          project: ipfs-desktop
+          release: ${{ env.RELEASE_NAME }}
+          path: '.' # upload all files in release
+
+          # configures installer support for mac and linux
+          install-name: ipfs-desktop
+          install-darwin-amd64: IPFS-Desktop-${{ env.RELEASE_NAME }}-mac.zip
+          install-darwin-arm64: IPFS-Desktop-${{ env.RELEASE_NAME }}-mac.zip
+          install-linux-amd64: ipfs-desktop-${{ env.RELEASE_NAME }}-linux-x86_64.AppImage


### PR DESCRIPTION
Hey frens!

After a lot of excellent conversations with the IPFS, Filecoin, and PL teams, we've built out the Valist GitHub Action to be super simple, and an easy way to get releases published onto IPFS and installable in a web3-native way!

This PR includes a simple workflow file addition that triggers upon a new GitHub Release, and mirrors the release onto Valist, including metadata for specifying supported platform/architecture combinations.

While we've modeled this PR off of the existing release flow, the IPFS Desktop team knows the pipeline best, so we're more than happy to modify this to better fit!

The only thing required for this to work is to add a repository secret called `VALIST_SIGNER` that contains a fresh Ethereum key -- then we can add that address to the `ipfs/ipfs-desktop` project on the Valist protocol to get the access control working. Thanks to gas-less transactions, there's no need to fund the key, it acts more like an SSH or PGP key in this context.

From there, it should automatically publish new IPFS Desktop versions, and will be installable in the Sapphire Launcher desktop client (essentially an app store for web3) :)

More info can be found here about the GitHub Action: https://docs.valist.io/quick-start/github-action

And here about the Sapphire Launcher: https://docs.valist.io/quick-start/sapphire-launcher

Looking forward to your feedback and to enabling a new way to download an install IPFS Desktop! 