### PR TITLE
chore: bump go-ipfs version to 0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "electron-updater": "^5.0.5",
         "fix-path": "3.0.0",
         "fs-extra": "^10.0.1",
-        "go-ipfs": "0.16.0-rc1",
+        "go-ipfs": "0.16.0",
         "i18next": "^21.8.14",
         "i18next-fs-backend": "1.1.4",
         "i18next-icu": "^2.0.3",
@@ -4940,9 +4940,9 @@
       }
     },
     "node_modules/go-ipfs": {
-      "version": "0.16.0-rc1",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.16.0-rc1.tgz",
-      "integrity": "sha512-OevQW1FTfEWJI/miQrIZAhQeaa05cKHvB+ZTYTYi7Z7bM16EeRimwjLTDZcWKM1pnbcJYGJ85JxePUYEbJascA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.16.0.tgz",
+      "integrity": "sha512-AxA/CGZgXlU3NCIAFJKdnCcF5TmOiryxtjxH4SmT7FdquAwemgQWzOWxUZzhDDzqlk32mqoDID2sVxmAOfcfcA==",
       "hasInstallScript": true,
       "dependencies": {
         "cachedir": "^2.3.0",
@@ -15502,9 +15502,9 @@
       }
     },
     "go-ipfs": {
-      "version": "0.16.0-rc1",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.16.0-rc1.tgz",
-      "integrity": "sha512-OevQW1FTfEWJI/miQrIZAhQeaa05cKHvB+ZTYTYi7Z7bM16EeRimwjLTDZcWKM1pnbcJYGJ85JxePUYEbJascA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.16.0.tgz",
+      "integrity": "sha512-AxA/CGZgXlU3NCIAFJKdnCcF5TmOiryxtjxH4SmT7FdquAwemgQWzOWxUZzhDDzqlk32mqoDID2sVxmAOfcfcA==",
       "requires": {
         "cachedir": "^2.3.0",
         "got": "^11.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "electron-updater": "^5.0.5",
         "fix-path": "3.0.0",
         "fs-extra": "^10.0.1",
-        "go-ipfs": "0.15.0",
+        "go-ipfs": "0.16.0-rc1",
         "i18next": "^21.8.14",
         "i18next-fs-backend": "1.1.4",
         "i18next-icu": "^2.0.3",
@@ -4940,9 +4940,9 @@
       }
     },
     "node_modules/go-ipfs": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.15.0.tgz",
-      "integrity": "sha512-Ischwb8Gs5FSr9cKUPNr6ZY1ukNcZNY0xyMUtbiR08zg4fB4vT6t2c5YMR9TglEfS1FlFpHyV77+RSkexYS/PA==",
+      "version": "0.16.0-rc1",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.16.0-rc1.tgz",
+      "integrity": "sha512-OevQW1FTfEWJI/miQrIZAhQeaa05cKHvB+ZTYTYi7Z7bM16EeRimwjLTDZcWKM1pnbcJYGJ85JxePUYEbJascA==",
       "hasInstallScript": true,
       "dependencies": {
         "cachedir": "^2.3.0",
@@ -15502,9 +15502,9 @@
       }
     },
     "go-ipfs": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.15.0.tgz",
-      "integrity": "sha512-Ischwb8Gs5FSr9cKUPNr6ZY1ukNcZNY0xyMUtbiR08zg4fB4vT6t2c5YMR9TglEfS1FlFpHyV77+RSkexYS/PA==",
+      "version": "0.16.0-rc1",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.16.0-rc1.tgz",
+      "integrity": "sha512-OevQW1FTfEWJI/miQrIZAhQeaa05cKHvB+ZTYTYi7Z7bM16EeRimwjLTDZcWKM1pnbcJYGJ85JxePUYEbJascA==",
       "requires": {
         "cachedir": "^2.3.0",
         "got": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "electron-updater": "^5.0.5",
     "fix-path": "3.0.0",
     "fs-extra": "^10.0.1",
-    "go-ipfs": "0.16.0-rc1",
+    "go-ipfs": "0.16.0",
     "i18next": "^21.8.14",
     "i18next-fs-backend": "1.1.4",
     "i18next-icu": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "electron-updater": "^5.0.5",
     "fix-path": "3.0.0",
     "fs-extra": "^10.0.1",
-    "go-ipfs": "0.15.0",
+    "go-ipfs": "0.16.0-rc1",
     "i18next": "^21.8.14",
     "i18next-fs-backend": "1.1.4",
     "i18next-icu": "^2.0.3",


### PR DESCRIPTION
Related https://github.com/ipfs/kubo/issues/9237