### PR TITLE
fix: adjust mac and dmg artifactName

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,15 +16,19 @@ asarUnpack: 'src/**/scripts/**/*'
 afterSign: './pkgs/macos/notarize-build.js'
 
 mac:
-  artifactName: ${name}-${version}-mac.${ext}
+  artifactName: ${name}-${version}-squirrel.${ext}
   category: public.app-category.utilities
   darkModeSupport: true
   hardenedRuntime: true
   gatekeeperAssess: false
   entitlements: './pkgs/macos/entitlements.mac.plist'
   entitlementsInherit: './pkgs/macos/entitlements.mac.plist'
+  target:
+    - zip
+    - dmg
 
 dmg:
+  artifactName: ${name}-${version}-mac.${ext}
   iconSize: 160
   iconTextSize: 12
   window:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,6 +16,7 @@ asarUnpack: 'src/**/scripts/**/*'
 afterSign: './pkgs/macos/notarize-build.js'
 
 mac:
+  artifactName: ${name}-${version}-mac.${ext}
   category: public.app-category.utilities
   darkModeSupport: true
   hardenedRuntime: true


### PR DESCRIPTION
This PR aims to close #2291  by changing implicit `artifactName` to explicit ones in `electron-builder.yml`, setting different ones for `.zip` and `.dmg` mac targets.

We can't remove .zip because of reasons described in https://github.com/ipfs/ipfs-desktop/issues/1922#issuecomment-991352450, but we can rename it to something  other than `-mac`.

## Old names

```
IPFS-Desktop-0.24.0.dmg
IPFS-Desktop-0.24.0.dmg.blockmap
IPFS-Desktop-0.24.0-mac.zip
IPFS.Desktop-0.24.0-mac.zip.blockmap
```

## New  names

```
ipfs-desktop-0.24.0-mac.dmg
ipfs-desktop-0.24.0-mac.dmg.blockmap
ipfs-desktop-0.24.0-squirrel.zip
ipfs-desktop-0.24.0-squirrel.zip.blockmap
```

