### PR TITLE
feat: Updating ipfs-webui CID to v2.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "force-webui-download": "shx rm -rf assets/webui && run-s build:webui",
     "build": "run-s clean build:webui",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c bafybeiavrvt53fks6u32n5p2morgblcmck4bh4ymf4rrwu7ah5zsykmqqa -p assets/webui/ -t 360000 --verbose -g \"https://dweb.link\" ",
+    "build:webui:download": "npx ipfs-or-gateway -c bafybeibjbq3tmmy7wuihhhwvbladjsd3gx3kfjepxzkq6wylik6wc3whzy -p assets/webui/ -t 360000 --verbose -g \"https://dweb.link\" ",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "package": "shx rm -rf dist/ && run-s build && electron-builder --publish onTag"
   },


### PR DESCRIPTION
https://github.com/ipfs/ipfs-webui/releases/tag/v2.20.0

Blocked By: https://github.com/protocol/bifrost-infra/issues/2186