### PR TITLE
Use CIDv1 by default

### DIFF
--- a/src/add-to-ipfs.js
+++ b/src/add-to-ipfs.js
@@ -40,7 +40,7 @@ async function getShareableCid (ipfs, files) {
   // because it handles HAMT-sharding of big directories automatically
   // See: https://github.com/ipfs/go-ipfs/issues/8106
   const dirpath = `/zzzz_${Date.now()}`
-  await ipfs.files.mkdir(dirpath, {})
+  await ipfs.files.mkdir(dirpath, { cidVersion: 1 })
 
   for (const { cid, filename } of files) {
     await ipfs.files.cp(`/ipfs/${cid}`, `${dirpath}/${filename}`)
@@ -88,12 +88,19 @@ async function addFileOrDirectory (ipfs, filepath) {
   let cid = null
 
   if (stat.isDirectory()) {
-    const files = globSource(filepath, '**/*', { recursive: true })
-    const res = await last(ipfs.addAll(files, { pin: false, wrapWithDirectory: true }))
+    const files = globSource(filepath, '**/*', { recursive: true, cidVersion: 1 })
+    const res = await last(ipfs.addAll(files, {
+      pin: false,
+      wrapWithDirectory: true,
+      cidVersion: 1
+    }))
     cid = res.cid
   } else {
     const readStream = fs.createReadStream(filepath)
-    const res = await ipfs.add(readStream, { pin: false })
+    const res = await ipfs.add(readStream, {
+      pin: false,
+      cidVersion: 1
+    })
     cid = res.cid
   }
 

--- a/test/unit/add-to-ipfs.spec.js
+++ b/test/unit/add-to-ipfs.spec.js
@@ -44,7 +44,7 @@ test.describe('Add To Ipfs', function () {
     expect(electron.clipboard.writeText.callCount).toEqual(1)
     expect(notify.notifyError.callCount).toEqual(0)
     expect(notify.notify.callCount).toEqual(1)
-    expect(cid.toString()).toEqual('QmWGeRAEgtsHW3ec7U4qW2CyVy7eA2mFRVbk1nb24jFyks')
+    expect(cid.toString()).toEqual('bafkreibrl5n5w5wqpdcdxcwaazheualemevr7ttxzbutiw74stdvrfhn2m')
   })
 
   test('add to ipfs single directory', async () => {
@@ -52,7 +52,7 @@ test.describe('Add To Ipfs', function () {
     expect(electron.clipboard.writeText.callCount).toEqual(1)
     expect(notify.notifyError.callCount).toEqual(0)
     expect(notify.notify.callCount).toEqual(1)
-    expect(cid.toString()).toEqual('QmVuxXkWEyCKvQiMqVnDiwyJUUyDQZ7VsKhQDCZzPj1Yq8')
+    expect(cid.toString()).toEqual('bafybeieyzpi3qdqtj7b7hfzdpt2mnmaiicvtrj7ngmf2fc76byecj62gea')
   })
 
   test('add to ipfs multiple files', async () => {
@@ -60,6 +60,6 @@ test.describe('Add To Ipfs', function () {
     expect(electron.clipboard.writeText.callCount).toEqual(1)
     expect(notify.notifyError.callCount).toEqual(0)
     expect(notify.notify.callCount).toEqual(1)
-    expect(cid.toString()).toEqual('QmdYASNGKMVK4HL1uzi3VCZyjQGg3M6VuLsgX5xTKL1gvH')
+    expect(cid.toString()).toEqual('bafybeiaqy3wawya5ryds5zs4nsxv7ulptbdtgfngipqin7ee65azaxs2uq')
   })
 })


### PR DESCRIPTION
IPFS desktop currently defaults to using CIDv0 when importing files and adding them to IPFS. This PR changes the default to use CIDv1. 

This should solve https://github.com/ipfs/ipfs-desktop/issues/2361 and make sure IPFS Desktop is using the most up-to-date CID standard.