### PR TITLE
fix: Fix incorrect link for Kubo version in tray icon

### DIFF
--- a/src/tray.js
+++ b/src/tray.js
@@ -176,7 +176,7 @@ function buildMenu (ctx) {
           label: hasCustomBinary()
             ? i18n.t('customIpfsBinary')
             : `kubo ${GO_IPFS_VERSION}`,
-          click: () => { shell.openExternal(`https://github.com/ipfs/kubo/releases/v${GO_IPFS_VERSION}`) }
+          click: () => { shell.openExternal(`https://github.com/ipfs/kubo/releases/v${GO_IPFS_VERSION.replace(/^\^/, '')}`) }
         },
         { type: 'separator' },
         {


### PR DESCRIPTION

Fixes #2424 


https://user-images.githubusercontent.com/53405160/235522592-00b660d8-0a4b-4ca7-b7d3-8ae98fc3c418.mp4

