### PR TITLE
fix: tray translation waits for i18n init

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -3,7 +3,7 @@ const pDefer = require('p-defer')
 const logger = require('./common/logger')
 
 /**
- * @typedef { 'tray' | 'tray-menu-state' | 'tray.update-menu' | 'countlyDeviceId' | 'manualCheckForUpdates' | 'startIpfs' | 'stopIpfs' | 'restartIpfs' | 'getIpfsd' | 'launchWebUI' | 'webui' | 'splashScreen'} ContextProperties
+ * @typedef { 'tray' | 'tray-menu-state' | 'tray.update-menu' | 'countlyDeviceId' | 'manualCheckForUpdates' | 'startIpfs' | 'stopIpfs' | 'restartIpfs' | 'getIpfsd' | 'launchWebUI' | 'webui' | 'splashScreen' | 'i18n_init_done' } ContextProperties
  */
 
 /**

--- a/src/context.js
+++ b/src/context.js
@@ -3,7 +3,7 @@ const pDefer = require('p-defer')
 const logger = require('./common/logger')
 
 /**
- * @typedef { 'tray' | 'tray-menu-state' | 'tray.update-menu' | 'countlyDeviceId' | 'manualCheckForUpdates' | 'startIpfs' | 'stopIpfs' | 'restartIpfs' | 'getIpfsd' | 'launchWebUI' | 'webui' | 'splashScreen' | 'i18n_init_done' } ContextProperties
+ * @typedef { 'tray' | 'tray-menu-state' | 'tray.update-menu' | 'countlyDeviceId' | 'manualCheckForUpdates' | 'startIpfs' | 'stopIpfs' | 'restartIpfs' | 'getIpfsd' | 'launchWebUI' | 'webui' | 'splashScreen' | 'i18n.initDone' } ContextProperties
  */
 
 /**

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -6,8 +6,10 @@ const Backend = require('i18next-fs-backend')
 const store = require('./common/store')
 const ipcMainEvents = require('./common/ipc-main-events')
 const logger = require('./common/logger')
+const getCtx = require('./context')
 
 module.exports = async function () {
+  const ctx = getCtx()
   logger.info('[i18n] init...')
   await i18n
     // @ts-expect-error
@@ -26,6 +28,7 @@ module.exports = async function () {
       }
     })
   logger.info('[i18n] init done')
+  ctx.setProp('i18n_init_done', true)
 
   ipcMain.on(ipcMainEvents.LANG_UPDATED, async (_, lang) => {
     if (lang === store.get('language')) {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -28,7 +28,7 @@ module.exports = async function () {
       }
     })
   logger.info('[i18n] init done')
-  ctx.setProp('i18n_init_done', true)
+  ctx.setProp('i18n.initDone', true)
 
   ipcMain.on(ipcMainEvents.LANG_UPDATED, async (_, lang) => {
     if (lang === store.get('language')) {

--- a/src/tray.js
+++ b/src/tray.js
@@ -43,6 +43,11 @@ async function buildMenu () {
   const stopIpfs = ctx.getFn('stopIpfs')
   const launchWebUI = ctx.getFn('launchWebUI')
   const manualCheckForUpdates = ctx.getFn('manualCheckForUpdates')
+  /**
+   * we need to wait for i18n to be ready before we translate the tray menu
+   * @type {boolean}
+   */
+  await ctx.getProp('i18n_init_done')
 
   // @ts-expect-error
   return Menu.buildFromTemplate([

--- a/src/tray.js
+++ b/src/tray.js
@@ -47,7 +47,7 @@ async function buildMenu () {
    * we need to wait for i18n to be ready before we translate the tray menu
    * @type {boolean}
    */
-  await ctx.getProp('i18n_init_done')
+  await ctx.getProp('i18n.initDone')
 
   // @ts-expect-error
   return Menu.buildFromTemplate([


### PR DESCRIPTION
The [lazy-loading ctx feature](https://github.com/ipfs/ipfs-desktop/pull/2378) didn't catch that i18n wasn't being init before tray translations were attempted.

That means the tray-menu-item translations were occurring prior to loading the
translation files, which defaults the translated result to the given key.

This PR resolves that problem.

fixes https://github.com/ipfs/ipfs-desktop/issues/2595

