### PR TITLE
ci: pin node-version to 18.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: '18.17.1'
 
       - name: Read ipfs-webui CID from package.json
         id: read-webui-version
@@ -89,7 +89,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: '18.17.1'
 
       - name: Read ipfs-webui CID from package.json
         id: read-webui-version
@@ -156,7 +156,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: '18.17.1'
 
       - name: Read ipfs-webui CID from package.json
         id: read-webui-version


### PR DESCRIPTION
Node 18.18.0 breaks `npm ci` command on Windows.