### PR TITLE
chore: webui v4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "force-webui-download": "shx rm -rf assets/webui && run-s build:webui",
     "build": "run-s clean build:webui",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c bafybeidf7cpkwsjkq6xs3r6fbbxghbugilx3jtezbza7gua3k5wjixpmba -p assets/webui/ -t 360000 --verbose -g \"https://trustless-gateway.link\" ",
+    "build:webui:download": "npx ipfs-or-gateway -c bafybeigggyffcf6yfhx5irtwzx3cgnk6n3dwylkvcpckzhqqrigsxowjwe -p assets/webui/ -t 360000 --verbose -g \"https://trustless-gateway.link\" ",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "package": "shx rm -rf dist/ && run-s build && electron-builder --publish onTag",
     "release-pr": "release-please release-pr --token=$GITHUB_TOKEN --plugin '@ipfs-shipyard/release-please-ipfs-plugin' --repo-url=ipfs/ipfs-desktop --trace --debug --draft-pull-request",


### PR DESCRIPTION
patch release that removes unnecessary requests to countly.ipfs.io which is no longer online 
closes #2743 

https://github.com/ipfs/ipfs-webui/releases/tag/v4.2.1