### PR TITLE
docs: link to faq on known error

### DIFF
--- a/src/dialogs/errors.js
+++ b/src/dialogs/errors.js
@@ -28,7 +28,20 @@ ${e.stack}
 
 let hasErrored = false
 
-const generateErrorIssueUrl = (e) => `https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?labels=kind%2Fbug%2C+need%2Ftriage&template=bug_report.md&title=${encodeURI(issueTitle(e))}&body=${encodeURI(issueTemplate(e))}`.substring(0, 1999)
+function generateErrorIssueUrl (e) {
+  // Check if error is one we have FAQ for
+  if (e && e.stack) {
+    const stack = e.stack
+    switch (true) {
+      case stack.includes('repo.lock'):
+        return 'https://github.com/ipfs/ipfs-desktop?tab=readme-ov-file#i-got-a-repolock-error-how-do-i-resolve-this'
+      case stack.includes('Error fetching'):
+        return 'https://github.com/ipfs/ipfs-desktop?tab=readme-ov-file#i-got-a-network-error-eg-error-fetching-what-should-i-do'
+    }
+  }
+  // Something else, prefill new issue form with error details
+  return `https://github.com/ipfs/ipfs-desktop/issues/new?labels=kind%2Fbug%2C+need%2Ftriage&template=bug_report.md&title=${encodeURI(issueTitle(e))}&body=${encodeURI(issueTemplate(e))}`.substring(0, 1999)
+}
 
 /**
  * This will fail and throw another application error if electron hasn't booted up properly.


### PR DESCRIPTION
We have the same errors reported over and over again and there is FAQ for them.

This PR ensures these errors are not reported anymore, but the user is routed to relevant FAQ entry instead, to self-service by following instructions from FAQ.

Closes #2744
Closes #2787
Closes #2807
Closes #2301
Closes #2754
Closes #2765
Closes #2768
Closes #2769
Closes #2791
Closes #2824