### PR TITLE
feat: kubo 0.33 with AutoTLS enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ipfs-utils": "^9.0.10",
         "ipfsd-ctl": "10.0.6",
         "it-last": "^1.0.6",
-        "kubo": "0.32.1",
+        "kubo": "0.33.0-rc3",
         "multiaddr": "10.0.1",
         "multiaddr-to-uri": "8.0.0",
         "portfinder": "^1.0.32",
@@ -9092,9 +9092,9 @@
       }
     },
     "node_modules/kubo": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.32.1.tgz",
-      "integrity": "sha512-vXTprOeWACNpU86ldCBSBMRgq4MahLIr/YBn6DBb0SvHHVe4ZD8Djma6ncfVmxzrWxEiIMq9XOxJcQ27UOZ6kw==",
+      "version": "0.33.0-rc3",
+      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.33.0-rc3.tgz",
+      "integrity": "sha512-3WVrvGPzrfzdpquxYwtxD2FVpfttOlLU//E/mIMXoRYvXO09WkrjUuVR4FmzIH5jLtxqqU4+WI9s2xSIy8+diw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -21943,9 +21943,9 @@
       }
     },
     "kubo": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.32.1.tgz",
-      "integrity": "sha512-vXTprOeWACNpU86ldCBSBMRgq4MahLIr/YBn6DBb0SvHHVe4ZD8Djma6ncfVmxzrWxEiIMq9XOxJcQ27UOZ6kw==",
+      "version": "0.33.0-rc3",
+      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.33.0-rc3.tgz",
+      "integrity": "sha512-3WVrvGPzrfzdpquxYwtxD2FVpfttOlLU//E/mIMXoRYvXO09WkrjUuVR4FmzIH5jLtxqqU4+WI9s2xSIy8+diw==",
       "requires": {
         "cachedir": "^2.3.0",
         "got": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ipfs-utils": "^9.0.10",
     "ipfsd-ctl": "10.0.6",
     "it-last": "^1.0.6",
-    "kubo": "0.32.1",
+    "kubo": "0.33.0-rc3",
     "multiaddr": "10.0.1",
     "multiaddr-to-uri": "8.0.0",
     "portfinder": "^1.0.32",


### PR DESCRIPTION
This PR 
- [ ] updates Kubo to 0.33 (https://github.com/ipfs/kubo/issues/10580) 
  - [ ] RC3
  - [ ] switch to FINAL 0.33
- [ ] enable AutoTLS by default
  - [ ] tray menu for toggling