### PR TITLE
fix:macos ipfs-desktop left click no focus

### DIFF
--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -141,6 +141,24 @@ module.exports = async function () {
 
   openExternal()
   const window = createWindow()
+
+if (process.platform === 'darwin') {
+  window.webContents.on('did-finish-load', () => {
+    window.webContents.insertCSS(`
+      input:not([type="hidden"]),
+      textarea,
+      select,
+      button,
+      [role="button"],
+      [contenteditable="true"] {
+        -webkit-app-region: no-drag !important;
+        app-region: no-drag !important;
+        pointer-events: auto;
+      }
+    `);
+  });
+}
+
   ctx.setProp('webui', window)
   let apiAddress = null
 


### PR DESCRIPTION
This fixes https://github.com/ipfs/ipfs-desktop/issues/2943 

**_Problem:_** On macOS, left-clicks on WebUI inputs didn’t focus because they sat inside an Electron draggable region (app-region: drag) that swallowed pointer events.
**_Solution_**: Injected CSS from the Electron shell to mark interactive controls as app-region: no-drag, restoring normal left/right click behavior across loads and in-page navigation.

