### PR TITLE
fix: prevent port replacement from corrupting IP addresses

### DIFF
--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -419,11 +419,11 @@ async function checkPorts (ipfsd) {
   }
 
   if (busyApiPort) {
-    config.Addresses.API = config.Addresses.API.replace(apiPort.toString(), freeApiPort.toString())
+    config.Addresses.API = config.Addresses.API.replace(`/tcp/${apiPort}`, `/tcp/${freeApiPort}`)
   }
 
   if (busyGatewayPort) {
-    config.Addresses.Gateway = config.Addresses.Gateway.replace(gatewayPort.toString(), freeGatewayPort.toString())
+    config.Addresses.Gateway = config.Addresses.Gateway.replace(`/tcp/${gatewayPort}`, `/tcp/${freeGatewayPort}`)
   }
 
   writeConfigFile(ipfsd, config)


### PR DESCRIPTION
the naive string replacement in checkPorts() could corrupt multiaddr IP addresses when the port number appeared in the IP portion.

for example, replacing port `0` in `/ip4/127.0.0.1/tcp/0` would match the first `0` in `127.0.0.1`, producing `/ip4/127.5001.0.1/tcp/0`.

this caused "invalid ip address" errors on startup when ports were busy.

fix by using `/tcp/${port}` pattern to match only the port component.

ref: https://discuss.ipfs.tech/t/invalid-ip-address/19925