### PR TITLE
Suppress/Fix nonsense warnings on build and on runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         with:
           package_manager: npm
           skip_package_manager_install: true
-          args: --publish onTagOrDraft # attach signed binaries to an existing release draft or when a tag is merged
+          args: --publish onTagOrDraft ${{ matrix.os == 'macos-latest' && '-c.afterSign=./pkgs/macos/notarize-build.js' || '' }} # attach signed binaries to an existing release draft or when a tag is merged
           release: false # keep github release as draft for manual inspection
           max_attempts: 2
           # GH token for attaching atrifacts to release draft on tag build
@@ -262,4 +262,3 @@ jobs:
 
       - name: Show Cache
         run: du -sh ${{ github.workspace }}/.cache/ && ls -l ${{ github.workspace }}/.cache/
-

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,8 +13,6 @@ directories:
 
 asarUnpack: 'src/**/scripts/**/*'
 
-afterSign: './pkgs/macos/notarize-build.js'
-
 mac:
   artifactName: ${name}-${version}-squirrel.${ext}
   category: public.app-category.utilities

--- a/patches/app-builder-lib+26.8.1.patch
+++ b/patches/app-builder-lib+26.8.1.patch
@@ -1,3 +1,17 @@
+diff --git a/node_modules/app-builder-lib/out/node-module-collector/nodeModulesCollector.js b/node_modules/app-builder-lib/out/node-module-collector/nodeModulesCollector.js
+index 8160257..219dfd1 100644
+--- a/node_modules/app-builder-lib/out/node-module-collector/nodeModulesCollector.js
++++ b/node_modules/app-builder-lib/out/node-module-collector/nodeModulesCollector.js
+@@ -320,7 +320,8 @@ class NodeModulesCollector {
+             const child = childProcess.spawn(command, args, {
+                 cwd,
+                 env: { COREPACK_ENABLE_STRICT: "0", ...process.env }, // allow `process.env` overrides
+-                shell: true, // `true`` is now required: https://github.com/electron-userland/electron-builder/issues/9488
++                // Linux emits DEP0190 when args are passed with shell=true; we only need shell wrapping on Windows.
++                shell: process.platform === "win32", // https://github.com/electron-userland/electron-builder/issues/9488
+             });
+             let stderr = "";
+             child.stdout.pipe(outStream);
 diff --git a/node_modules/app-builder-lib/scheme.json b/node_modules/app-builder-lib/scheme.json
 index 2eadec7..d55eced 100644
 --- a/node_modules/app-builder-lib/scheme.json


### PR DESCRIPTION
This PR fixes:

- DEP0190 build warning on Linux (suppressed)
- DEP0180 runtime warnings (upstream bug)
- `afterSign` build warning on Linux (limited operation to MacOS)

Testing: I can only test on Linux, and I tested the core functionality of the app with Electron `39.5.1`.