### PR TITLE
build: reduce duplicate dependency reference log noise

### DIFF
--- a/patches/app-builder-lib+26.8.1.patch
+++ b/patches/app-builder-lib+26.8.1.patch
@@ -24,3 +24,16 @@ index 2eadec7..d55eced 100644
          },
          "timestampDigest": {
            "default": "SHA256",
+diff --git a/node_modules/app-builder-lib/out/node-module-collector/moduleManager.js b/node_modules/app-builder-lib/out/node-module-collector/moduleManager.js
+index 5b9d392..57fe71c 100644
+--- a/node_modules/app-builder-lib/out/node-module-collector/moduleManager.js
++++ b/node_modules/app-builder-lib/out/node-module-collector/moduleManager.js
+@@ -15,7 +15,7 @@ var LogMessageByKey;
+     LogMessageByKey["PKG_COLLECTOR_OUTPUT"] = "collector stderr output";
+ })(LogMessageByKey || (exports.LogMessageByKey = LogMessageByKey = {}));
+ exports.logMessageLevelByKey = {
+-    [LogMessageByKey.PKG_DUPLICATE_REF]: "info",
++    [LogMessageByKey.PKG_DUPLICATE_REF]: "debug",
+     [LogMessageByKey.PKG_NOT_FOUND]: "warn",
+     [LogMessageByKey.PKG_NOT_ON_DISK]: "warn",
+     [LogMessageByKey.PKG_SELF_REF]: "debug",


### PR DESCRIPTION
Add patch to downgrade `PKG_DUPLICATE_REF` from `info` to `debug` to remove this non-actionable noise from the build log:

```
  • duplicate dependency references  dependencies=["uri-js@4.4.1","find-up@3.0.0","debug@4.3.4","fs-
extra@10.1.0","intl-messageformat@9.13.0","@formatjs/ecma402-abstract@1.11.4","@formatjs/ecma402-
abstract@1.11.4","@ipld/dag-pb@2.1.15","uint8arrays@3.0.0","@types/
node@24.10.13","multiaddr@10.0.1","debug@4.3.4","ipfs-core-types@0.10.3","ipfs-unixfs@6.0.6","ipfs-
utils@9.0.14","it-to-stream@1.0.0","merge-options@3.0.4","multiaddr-to-
uri@8.0.0","multiaddr@10.0.1","uint8arrays@3.0.0","ipfs-
utils@9.0.14","multiaddr@10.0.1","string_decoder@1.1.1","merge-options@3.0.4","node-
fetch@2.7.0","encoding@0.1.13","stream-to-it@0.2.4","@hapi/boom@9.1.1","@hapi/boom@9.1.1","@hapi/
boom@9.1.1","@hapi/boom@9.1.1","@hapi/boom@9.1.1","@hapi/boom@9.1.1","@hapi/podium@4.1.1","@hapi/
validate@1.1.3","@hapi/boom@9.1.1","@hapi/validate@1.1.3","@hapi/validate@1.1.3","@hapi/
validate@1.1.3","@hapi/bounce@2.0.0","@hapi/boom@9.1.1","@hapi/bounce@2.0.0","@hapi/boom@9.1.1","@hapi/
boom@9.1.1","@hapi/cryptiles@5.1.0","@hapi/validate@1.1.3","@hapi/boom@9.1.1","@hapi/boom@9.1.1","@hapi/
b64@5.0.0","@hapi/boom@9.1.1","@hapi/content@5.0.2","@hapi/boom@9.1.1","@hapi/
topo@5.0.0","debug@4.3.4","onetime@5.1.2","ipfs-utils@9.0.14","@hapi/topo@5.0.0","merge-
options@3.0.4","multiaddr@10.0.1","@types/node@24.10.13","@types/responselike@1.0.0","@types/
node@24.10.13","end-of-stream@1.4.4","once@1.4.0","responselike@2.0.1","end-of-stream@1.4.4","readable-
stream@2.3.7","through2@2.0.5","duplexify@3.7.1","end-of-
stream@1.4.4","once@1.4.0","string_decoder@1.1.1","once@1.4.0","string_decoder@1.1.1","end-of-
stream@1.4.4","string_decoder@1.1.1","mkdirp@0.5.6","multiaddr@10.0.1","debug@4.3.4","uint8arrays@3.0.0"
,"logform@2.4.0","string_decoder@1.1.1"]
```

Which is caused by electron-builder's node-module collector reading npm's resolved dependency tree (`npm list --json --long`) and reporting repeated reference nodes as duplicates; these are expected tree references, not duplicate entries in our manifest/lock files.

This change downgrades that specific log category to debug to reduce build log noise while keeping real warnings visible.

Testing: I can only test on Linux, and I tested the core functionality of the app with Electron `39.5.1`.
