### PR TITLE
build: dependency replacements

### DIFF
--- a/npm-overrides/boolean-compat/index.js
+++ b/npm-overrides/boolean-compat/index.js
@@ -1,0 +1,31 @@
+'use strict'
+
+function boolean (value) {
+  const tag = Object.prototype.toString.call(value)
+  switch (tag) {
+    case '[object String]':
+      return ['true', 't', 'yes', 'y', 'on', '1'].includes(String(value).trim().toLowerCase())
+    case '[object Number]':
+      return Number(value) === 1
+    case '[object Boolean]':
+      return Boolean(value.valueOf())
+    default:
+      return false
+  }
+}
+
+function isBooleanable (value) {
+  if (Object.prototype.toString.call(value) === '[object String]') {
+    const normalized = String(value).trim().toLowerCase()
+    return ['true', 't', 'yes', 'y', 'on', '1', 'false', 'f', 'no', 'n', 'off', '0'].includes(normalized)
+  }
+  if (Object.prototype.toString.call(value) === '[object Number]') {
+    return Number(value) === 0 || Number(value) === 1
+  }
+  return Object.prototype.toString.call(value) === '[object Boolean]'
+}
+
+module.exports = {
+  boolean,
+  isBooleanable
+}

--- a/npm-overrides/boolean-compat/package.json
+++ b/npm-overrides/boolean-compat/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "boolean",
+  "version": "3.2.0-ipfs.0",
+  "description": "Compatibility shim for boolean package API",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/npm-overrides/lodash.isequal-compat/index.js
+++ b/npm-overrides/lodash.isequal-compat/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const { isDeepStrictEqual } = require('node:util')
+
+module.exports = function isEqual (value, other) {
+  return isDeepStrictEqual(value, other)
+}

--- a/npm-overrides/lodash.isequal-compat/package.json
+++ b/npm-overrides/lodash.isequal-compat/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lodash.isequal",
+  "version": "4.5.0-ipfs.0",
+  "description": "Compatibility shim using node:util.isDeepStrictEqual",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5240,6 +5240,7 @@
         "node": ">=10"
       }
     },
+    "node_modules/electron-updater/npm-overrides/lodash.isequal-compat": {},
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -8732,9 +8733,8 @@
       "dev": true
     },
     "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+      "resolved": "node_modules/electron-updater/npm-overrides/lodash.isequal-compat",
+      "link": true
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -18105,7 +18105,7 @@
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
-        "lodash.isequal": "^4.5.0",
+        "lodash.isequal": "file:npm-overrides/lodash.isequal-compat",
         "semver": "~7.7.3",
         "tiny-typed-emitter": "^2.1.0"
       },
@@ -20749,9 +20749,7 @@
       "dev": true
     },
     "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+      "version": "file:node_modules/electron-updater/npm-overrides/lodash.isequal-compat"
     },
     "lodash.ismatch": {
       "version": "4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3322,11 +3322,8 @@
       "peer": true
     },
     "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "dev": true,
-      "optional": true
+      "resolved": "node_modules/global-agent/npm-overrides/boolean-compat",
+      "link": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -6732,6 +6729,10 @@
       "engines": {
         "node": ">=10.0"
       }
+    },
+    "node_modules/global-agent/npm-overrides/boolean-compat": {
+      "dev": true,
+      "optional": true
     },
     "node_modules/globalthis": {
       "version": "1.0.3",
@@ -11784,10 +11785,18 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/roarr/node_modules/boolean": {
+      "resolved": "node_modules/roarr/npm-overrides/boolean-compat",
+      "link": true
+    },
     "node_modules/roarr/node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/roarr/npm-overrides/boolean-compat": {
       "dev": true,
       "optional": true
     },
@@ -16673,11 +16682,7 @@
       "peer": true
     },
     "boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "dev": true,
-      "optional": true
+      "version": "file:node_modules/global-agent/npm-overrides/boolean-compat"
     },
     "brace-expansion": {
       "version": "1.1.12",
@@ -19230,7 +19235,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boolean": "^3.0.1",
+        "boolean": "file:npm-overrides/boolean-compat",
         "es6-error": "^4.1.1",
         "matcher": "^3.0.0",
         "roarr": "^2.15.3",
@@ -23007,7 +23012,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boolean": "^3.0.1",
+        "boolean": "file:npm-overrides/boolean-compat",
         "detect-node": "^2.0.4",
         "globalthis": "^1.0.1",
         "json-stringify-safe": "^5.0.1",
@@ -23015,6 +23020,9 @@
         "sprintf-js": "^1.1.2"
       },
       "dependencies": {
+        "boolean": {
+          "version": "file:node_modules/roarr/npm-overrides/boolean-compat"
+        },
         "sprintf-js": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "ipfs-http-client": "56.0.2",
         "ipfs-utils": "^9.0.10",
         "ipfsd-ctl": "10.0.6",
-        "it-last": "^1.0.6",
         "kubo": "0.40.1",
         "multiaddr": "10.0.1",
         "multiaddr-to-uri": "8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "multiaddr": "10.0.1",
         "multiaddr-to-uri": "8.0.0",
         "portfinder": "^1.0.32",
-        "untildify": "^4.0.0",
         "v8-compile-cache": "^2.4.0",
         "winston": "^3.7.2"
       },
@@ -13610,14 +13609,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/untildify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/unzip-stream": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.4.tgz",
@@ -24390,11 +24381,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-    },
-    "untildify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
     },
     "unzip-stream": {
       "version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "release-gh": "release-please github-release --token=$GITHUB_TOKEN --plugin '@ipfs-shipyard/release-please-ipfs-plugin' --repo-url=ipfs/ipfs-desktop --trace --debug --draft"
   },
   "overrides": {
-    "boolean": "file:./npm-overrides/boolean-compat"
+    "boolean": "file:./npm-overrides/boolean-compat",
+    "lodash.isequal": "file:./npm-overrides/lodash.isequal-compat"
   },
   "pre-commit": [
     "lint"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "multiaddr": "10.0.1",
     "multiaddr-to-uri": "8.0.0",
     "portfinder": "^1.0.32",
-    "untildify": "^4.0.0",
     "v8-compile-cache": "^2.4.0",
     "winston": "^3.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "ipfs-http-client": "56.0.2",
     "ipfs-utils": "^9.0.10",
     "ipfsd-ctl": "10.0.6",
-    "it-last": "^1.0.6",
     "kubo": "0.40.1",
     "multiaddr": "10.0.1",
     "multiaddr-to-uri": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "release-pr": "release-please release-pr --token=$GITHUB_TOKEN --plugin '@ipfs-shipyard/release-please-ipfs-plugin' --repo-url=ipfs/ipfs-desktop --trace --debug --draft-pull-request",
     "release-gh": "release-please github-release --token=$GITHUB_TOKEN --plugin '@ipfs-shipyard/release-please-ipfs-plugin' --repo-url=ipfs/ipfs-desktop --trace --debug --draft"
   },
+  "overrides": {
+    "boolean": "file:./npm-overrides/boolean-compat"
+  },
   "pre-commit": [
     "lint"
   ],

--- a/src/add-to-ipfs.js
+++ b/src/add-to-ipfs.js
@@ -2,12 +2,19 @@ const { extname, basename } = require('path')
 const { clipboard } = require('electron')
 const { globSource } = require('ipfs-http-client')
 const i18n = require('i18next')
-const last = require('it-last')
 const fs = require('fs-extra')
 const logger = require('./common/logger')
 const { notify, notifyError } = require('./common/notify')
 const { analyticsKeys } = require('./analytics/keys')
 const getCtx = require('./context')
+
+async function lastItem (iterable) {
+  let value
+  for await (const item of iterable) {
+    value = item
+  }
+  return value
+}
 
 async function copyFileToMfs (ipfs, cid, filename) {
   let i = 0
@@ -91,7 +98,7 @@ async function addFileOrDirectory (ipfs, filepath) {
 
   if (stat.isDirectory()) {
     const files = globSource(filepath, '**/*', { recursive: true, cidVersion: 1 })
-    const res = await last(ipfs.addAll(files, {
+    const res = await lastItem(ipfs.addAll(files, {
       pin: false,
       wrapWithDirectory: true,
       cidVersion: 1

--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -1,10 +1,9 @@
 // @ts-check
 const { app } = require('electron')
 const i18n = require('i18next')
-const os = require('os')
-const path = require('path')
+const os = require('node:os')
+const path = require('node:path')
 const fs = require('fs-extra')
-const untildify = require('untildify')
 const createToggler = require('./utils/create-toggler')
 const logger = require('./common/logger')
 const store = require('./common/store')
@@ -18,7 +17,7 @@ function isSupported () {
 }
 
 function getDesktopFile () {
-  return path.join(untildify('~/.config/autostart/'), 'ipfs-desktop.desktop')
+  return path.join(os.homedir(), '.config/autostart/', 'ipfs-desktop.desktop')
 }
 
 async function enable () {


### PR DESCRIPTION
This PR removes 4 dependencies:

- `isequal` for being deprecated
- `boolean` for being deprecated
- `untildify` for being just a wrapper around os.home() at our one call site.
- `it-last` for being just used for a single function at a single call site, which has just 3 SLOC

This reduces code size by 640 KByte on disk (install size).


Testing: I can only test on Linux, and I tested the core functionality of the app with Electron `39.5.1`.