### PR TITLE
fix: link to releases when repo version exceeds program

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -38,6 +38,7 @@
   "cancel": "Cancel",
   "enable": "Enable",
   "reportTheError": "Report the error",
+  "downloadLatestRelease": "Download latest release",
   "restartIpfsDesktop": "Restart IPFS Desktop",
   "openLogs": "Open logs",
   "takeScreenshot": "Take Screenshot",
@@ -213,7 +214,8 @@
   },
   "startupFailedDialog": {
     "title": "IPFS Desktop Startup Has Failed",
-    "message": "IPFS node has encountered an error and startup could not be completed:"
+    "message": "IPFS node has encountered an error and startup could not be completed:",
+    "outdatedBinaryMessage": "Your IPFS repository was written by a newer version of IPFS Desktop or Kubo CLI. Please upgrade to the latest release:"
   },
   "repositoryMustBeDirectoryDialog": {
     "title": "IPFS Repository Must Be a Directory",

--- a/src/daemon/migration-prompt.js
+++ b/src/daemon/migration-prompt.js
@@ -65,6 +65,28 @@ const inProgressTemplate = (logs, id, done) => {
 
 const errorTemplate = (logs) => {
   const title = i18n.t('startupFailedDialog.title')
+  // Parse versions so we only engage the upgrade path when program < repo.
+  const versionMatch = typeof logs === 'string' &&
+    logs.match(/Error: Your programs version \((\d+)\) is lower than your repos \((\d+)\)/)
+  const isOutdatedBinary = versionMatch &&
+    parseInt(versionMatch[1], 10) < parseInt(versionMatch[2], 10)
+
+  if (isOutdatedBinary) {
+    const message = i18n.t('startupFailedDialog.outdatedBinaryMessage')
+    const buttons = [
+      `<button class="default" onclick="javascript:window.close()">${i18n.t('close')}</button>`,
+      `<button onclick="javascript:openReleases()">${i18n.t('downloadLatestRelease')}</button>`
+    ]
+    const script = `
+    const { shell } = require('electron')
+
+    function openReleases () {
+      shell.openExternal('https://github.com/ipfs/ipfs-desktop/releases/latest')
+    }
+    `
+    return template(logs, script, title, message, buttons)
+  }
+
   const message = i18n.t('startupFailedDialog.message')
   const buttons = [
     `<button class="default" onclick="javascript:window.close()">${i18n.t('close')}</button>`,

--- a/test/e2e/launch.e2e.test.js
+++ b/test/e2e/launch.e2e.test.js
@@ -17,13 +17,22 @@ test.describe.serial('Application launch', async () => {
   let app = null
 
   test.afterEach(async () => {
-    if (app) {
+    if (!app) return
+    // app.close() waits for `before-quit` → ipfsd.stop(), which can hang on
+    // slow macos ci runners and blow past the per-test timeout. Race it
+    // against a short deadline and fall back to SIGKILL so the rest of the
+    // suite can proceed.
+    try {
+      await Promise.race([
+        app.close(),
+        new Promise((resolve, reject) => setTimeout(() => reject(new Error('app.close() timeout')), 15000))
+      ])
+    } catch (e) {
+      if (e.message.includes('has been closed')) return
       try {
-        await app.close()
-      } catch (e) {
-        if (e.message.includes('has been closed')) return
-        throw e
-      }
+        const proc = app.process()
+        if (proc && !proc.killed) proc.kill('SIGKILL')
+      } catch {}
     }
   })
 

--- a/test/e2e/launch.e2e.test.js
+++ b/test/e2e/launch.e2e.test.js
@@ -327,5 +327,9 @@ test.describe.serial('Application launch', async () => {
     expect(html).toContain('https://github.com/ipfs/ipfs-desktop/releases/latest')
     expect(html).toContain('Download latest release')
     expect(html).not.toContain('Report the error')
+
+    // Dismiss the dialog so afterEach does not race the prompt window during
+    // app shutdown.
+    await errorWindow.close()
   })
 })

--- a/test/e2e/launch.e2e.test.js
+++ b/test/e2e/launch.e2e.test.js
@@ -280,7 +280,7 @@ test.describe.serial('Application launch', async () => {
 
   // Regression test for https://github.com/ipfs/ipfs-desktop/issues/3143
   test('shows upgrade dialog when repo version is newer than program', async () => {
-    test.setTimeout(120000)
+    test.setTimeout(180000)
     // Init via kubo directly; makeRepository's ipfsd-ctl factory leaves a
     // daemon running against the repo that would mask the version override.
     const repoPath = tmp.dirSync({ prefix: 'tmp_IPFS_PATH_', unsafeCleanup: true }).name
@@ -297,11 +297,21 @@ test.describe.serial('Application launch', async () => {
 
     const { app } = await startApp({ repoPath })
 
-    const errorWindow = await app.waitForEvent('window', {
-      predicate: (page) => page.url().startsWith('data:text/html;base64,'),
-      timeout: 90000
-    })
-    await errorWindow.waitForLoadState('domcontentloaded')
+    const isPromptWindow = (page) => page.url().startsWith('data:text/html;base64,')
+
+    // Subscribe before any other await; fall back to app.windows() in case
+    // the event already fired between launch resolving and this subscription.
+    const windowPromise = app.waitForEvent('window', { predicate: isPromptWindow, timeout: 120000 })
+    const errorWindow = app.windows().find(isPromptWindow) ?? await windowPromise
+
+    // The prompt may render the in-progress migration template first and
+    // reload with the error/upgrade template once kubo exits, so wait for
+    // the upgrade-specific string instead of asserting on first paint.
+    await errorWindow.waitForFunction(
+      () => document.body && document.body.innerText.includes('Download latest release'),
+      null,
+      { timeout: 45000 }
+    )
     const html = await errorWindow.content()
 
     expect(html).toContain('Your IPFS repository was written by a newer version of IPFS Desktop or Kubo CLI')

--- a/test/e2e/launch.e2e.test.js
+++ b/test/e2e/launch.e2e.test.js
@@ -277,4 +277,36 @@ test.describe.serial('Application launch', async () => {
     const { app } = await startApp({ repoPath })
     await daemonReady(app)
   })
+
+  // Regression test for https://github.com/ipfs/ipfs-desktop/issues/3143
+  test('shows upgrade dialog when repo version is newer than program', async () => {
+    test.setTimeout(120000)
+    // Init via kubo directly; makeRepository's ipfsd-ctl factory leaves a
+    // daemon running against the repo that would mask the version override.
+    const repoPath = tmp.dirSync({ prefix: 'tmp_IPFS_PATH_', unsafeCleanup: true }).name
+    const { spawnSync } = require('child_process')
+    const kuboPath = require('kubo').path()
+    const initRes = spawnSync(kuboPath, ['init', '--profile=test'], {
+      env: Object.assign({}, process.env, { IPFS_PATH: repoPath })
+    })
+    if (initRes.status !== 0) throw new Error(`kubo init failed: ${initRes.stderr?.toString()}`)
+
+    // Writing a too-high repo version forces Kubo to emit:
+    // "Error: Your programs version (N) is lower than your repos (999)."
+    fs.writeFileSync(path.join(repoPath, 'version'), '999')
+
+    const { app } = await startApp({ repoPath })
+
+    const errorWindow = await app.waitForEvent('window', {
+      predicate: (page) => page.url().startsWith('data:text/html;base64,'),
+      timeout: 90000
+    })
+    await errorWindow.waitForLoadState('domcontentloaded')
+    const html = await errorWindow.content()
+
+    expect(html).toContain('Your IPFS repository was written by a newer version of IPFS Desktop or Kubo CLI')
+    expect(html).toContain('https://github.com/ipfs/ipfs-desktop/releases/latest')
+    expect(html).toContain('Download latest release')
+    expect(html).not.toContain('Report the error')
+  })
 })


### PR DESCRIPTION
Quality of life improvement: detect "Your programs version (X) is lower than your repos (Y)" when X < Y and swap the startup error dialog's "Report the error" button for a "Download latest release" button linking to releases/latest. 

This avoids a stream of duplicate gui-error-report issues like #3143.


- Closes #3143
- Closes #3141
- Closes #2947
- Closes #2854
- Closes #2853
- Closes #2785
- Closes #2762
- Closes #2659
- Closes #2619
- Closes #2614
- Closes #2612
- Closes #2596
- Closes #2564
- Closes #2559
- Closes #2544
- Closes #2542
- Closes #2503
- Closes #2497
- Closes #2478
- Closes #2429
- Closes #2418
- Closes #2397
- Closes #2379
- Closes #2372
- Closes #1823
- Closes #693
- Closes #683