### PR TITLE
feat: provide strategy tray menu

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -194,7 +194,14 @@
     "default": "Default",
     "cidv1": "CIDv1 (unixfs-v1-2025)",
     "cidv0Legacy": "Legacy CIDv0 (unixfs-v0-2015)",
-    "manual": "Manual Import.* Config"
+    "manual": "Manually edited in Kubo config"
+  },
+  "provideStrategy": {
+    "title": "Provide Strategy",
+    "default": "Default (announce all local blocks)",
+    "pinnedMfs": "Pinned + Files (MFS)",
+    "pinned": "Pinned Only",
+    "manual": "Manually edited in Kubo config"
   },
   "setCustomIpfsBinaryConfirmation": {
     "title": "Custom IPFS binary",

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -191,16 +191,16 @@
   },
   "cidProfile": {
     "title": "CID Profile",
-    "default": "Default",
-    "cidv1": "CIDv1 (unixfs-v1-2025)",
+    "default": "Default (Kubo built-ins)",
+    "cidv1": "Modern CIDv1 (unixfs-v1-2025)",
     "cidv0Legacy": "Legacy CIDv0 (unixfs-v0-2015)",
     "manual": "Manually edited in Kubo config"
   },
   "provideStrategy": {
     "title": "Provide Strategy",
-    "default": "Default (announce all local blocks)",
-    "pinnedMfs": "Pinned + Files (MFS)",
-    "pinned": "Pinned Only",
+    "default": "All Files, Pins, and Browsing Cache (default)",
+    "pinnedMfs": "Only Files and Pins",
+    "pinned": "Only Pins",
     "manual": "Manually edited in Kubo config"
   },
   "setCustomIpfsBinaryConfirmation": {

--- a/src/cid-profile.js
+++ b/src/cid-profile.js
@@ -6,12 +6,6 @@ const { kuboApiPost } = require('./common/kubo-rpc')
 const { STATUS } = require('./daemon/consts')
 const getCtx = require('./context')
 
-// Meaning of "Default" when Import.* is empty. Sets the cid-version passed
-// to `files/chcid` on a Default selection. Our chosen fallback, not Kubo's
-// built-in default. Change this literal to flip the meaning of "Default"
-// in a future release.
-const DEFAULT_PROFILE = 'unixfs-v0-2015'
-
 const PROFILES = {
   'unixfs-v1-2025': {
     Import: {
@@ -42,8 +36,6 @@ const PROFILES = {
     }
   }
 }
-
-const DEFAULT_CHCID_VERSION = PROFILES[DEFAULT_PROFILE].Import.CidVersion
 
 async function fetchImportConfig (ipfsd) {
   const raw = await kuboApiPost(ipfsd, '/api/v0/config?arg=Import')
@@ -105,23 +97,17 @@ async function applyCidProfile (ipfsd, profileName) {
     const encodedValue = encodeURIComponent(JSON.stringify(merged))
     await kuboApiPost(ipfsd, `/api/v0/config?arg=Import&arg=${encodedValue}&json=true`)
 
-    // chcid re-hashes the MFS root under the new CID version. It takes
-    // effect live (no daemon restart) but requires a running daemon, so
-    // we call it here rather than in the reconcile path.
-    step = 'chcid'
-    const cidVersion = profileName === 'default'
-      ? DEFAULT_CHCID_VERSION
-      : PROFILES[profileName].Import.CidVersion
-    await kuboApiPost(ipfsd, `/api/v0/files/chcid?arg=/&cid-version=${cidVersion}`)
-
-    // Persist, then restart the daemon so the embedded WebUI re-reads the
-    // config and shows the new CID version in Files and Settings.
+    // Persist, then restart the daemon. Kubo 0.41+ reads Import.CidVersion
+    // and Import.HashFunction at startup and applies them to the MFS root
+    // CidBuilder (kubo/#11273), so the new format takes effect on the next
+    // MFS mutation. No explicit `files/chcid` is needed; calling it on '/'
+    // returns an error in 0.41+.
     step = 'persist'
     await store.safeSet('cidProfile', profileName, () => {
       ipcMain.emit(ipcMainEvents.IPFS_CONFIG_CHANGED)
     })
 
-    logger.info(`[cid-profile] applied '${profileName}' (cid-version=${cidVersion})`)
+    logger.info(`[cid-profile] applied '${profileName}'`)
   } catch (err) {
     logger.error(`[cid-profile] ${step} failed for '${profileName}': ${err.message}`)
   }

--- a/src/cid-profile.js
+++ b/src/cid-profile.js
@@ -1,8 +1,8 @@
 const { ipcMain } = require('electron')
-const http = require('http')
 const store = require('./common/store')
 const logger = require('./common/logger')
 const ipcMainEvents = require('./common/ipc-main-events')
+const { kuboApiPost } = require('./common/kubo-rpc')
 const { STATUS } = require('./daemon/consts')
 const getCtx = require('./context')
 
@@ -45,96 +45,64 @@ const PROFILES = {
 
 const DEFAULT_CHCID_VERSION = PROFILES[DEFAULT_PROFILE].Import.CidVersion
 
-// TODO: drop this raw HTTP helper once the project switches to
-// kubo-rpc-client. The client exposes config.get / config.set / files.chcid
-// and handles auth headers, query encoding, and IPv6 for us.
-function kuboApiPost (ipfsd, apiPath) {
-  return new Promise((resolve, reject) => {
-    const { address, port } = ipfsd.apiAddr.nodeAddress()
-
-    const req = http.request({
-      method: 'POST',
-      hostname: address,
-      port,
-      path: apiPath,
-      timeout: 30000
-    }, (res) => {
-      let data = ''
-      res.on('data', chunk => { data += chunk })
-      res.on('end', () => {
-        if (res.statusCode === 200) {
-          resolve(data)
-        } else {
-          reject(new Error(`kubo API ${apiPath} returned status ${res.statusCode}: ${data}`))
-        }
-      })
-    })
-
-    req.on('error', reject)
-    req.on('timeout', () => {
-      req.destroy()
-      reject(new Error(`kubo API ${apiPath} request timed out`))
-    })
-    req.end()
-  })
-}
-
 async function fetchImportConfig (ipfsd) {
   const raw = await kuboApiPost(ipfsd, '/api/v0/config?arg=Import')
   const parsed = JSON.parse(raw)
-  return parsed.Value
+  return parsed.Value || {}
 }
 
-function matchesProfile (importSection, profileImport) {
-  const profileKeys = Object.keys(profileImport)
+// Union of Import.* keys cid-profile owns. Detection projects Import to
+// these keys only, so unrelated Import.* fields (future kubo schema
+// additions, another module's keys like provide-strategy's FastProvide*)
+// cannot trigger 'manual'.
+const PROFILE_KEYS = new Set(
+  Object.values(PROFILES).flatMap(p => Object.keys(p.Import))
+)
 
-  // Every profile key must match
-  for (const key of profileKeys) {
-    if (importSection[key] !== profileImport[key]) return false
+function matchesProfile (knownImport, profileImport) {
+  for (const key of Object.keys(profileImport)) {
+    if (knownImport[key] !== profileImport[key]) return false
   }
-
-  // Kubo serializes unset schema fields as null. Tolerating extra null keys
-  // keeps a profile matching after Kubo adds new Import.* fields in a future
-  // release. A non-null extra means the user set something unknown to us,
-  // so treat the config as manual.
-  for (const key of Object.keys(importSection)) {
-    if (!profileKeys.includes(key) && importSection[key] !== null) return false
-  }
-
   return true
 }
 
 function detectCurrentProfile (importSection) {
-  // Missing or empty Import section: pristine, never customized.
-  if (!importSection || Object.keys(importSection).length === 0) return 'default'
-  // After applyCidProfile('default') writes `Import = {}`, Kubo echoes the
-  // section back with every schema field as null. This early-return keeps
-  // that state classified as 'default'; without it, matchesProfile rejects
-  // the null entries (null !== 1, null !== 'size-1048576') and the next
-  // daemon start misclassifies the state as 'manual'.
-  if (Object.values(importSection).every(v => v === null)) return 'default'
-
-  for (const [name, profile] of Object.entries(PROFILES)) {
-    if (matchesProfile(importSection, profile.Import)) return name
+  // Project to the cid-profile keyset. Missing keys become null so partial
+  // sections behave the same as fully-serialized ones.
+  const known = {}
+  for (const key of PROFILE_KEYS) {
+    known[key] = importSection?.[key] ?? null
   }
 
-  // A populated Import.* that matches no profile means the user edited the
-  // config by hand. Surface it as a read-only "Manual" state so we keep
-  // their edits intact.
+  // Every cid-profile key is null: pristine, just-cleared, or only
+  // unrelated Import.* fields edited. Show "Default".
+  if (Object.values(known).every(v => v === null)) return 'default'
+
+  for (const [name, profile] of Object.entries(PROFILES)) {
+    if (matchesProfile(known, profile.Import)) return name
+  }
+
+  // At least one cid-profile key has a non-null value matching no known
+  // profile. The user hand-tuned cid-relevant settings; show "Manual"
+  // (read-only) so a tray click cannot overwrite them.
   return 'manual'
 }
 
 async function applyCidProfile (ipfsd, profileName) {
   let step = 'init'
   try {
-    // Write Import.* through the RPC API rather than the config file, so we
-    // never race with Kubo's own config writer. Selecting "Default" clears
-    // the section; Kubo then applies its built-ins.
+    // Write Import.* through the RPC API rather than the config file to
+    // avoid racing with Kubo's own config writer. Read-merge-write so we
+    // touch only the cid-profile keyset and preserve foreign Import.*
+    // fields (provide-strategy's FastProvide*, hand-set values, future
+    // kubo additions). "Default" nulls our keys, leaving Kubo to apply
+    // its built-ins.
     step = 'config write'
-    const importValue = profileName === 'default'
-      ? {}
-      : { ...PROFILES[profileName].Import }
-    const encodedValue = encodeURIComponent(JSON.stringify(importValue))
+    const existing = await fetchImportConfig(ipfsd)
+    const merged = { ...existing }
+    for (const key of PROFILE_KEYS) merged[key] = null
+    if (profileName !== 'default') Object.assign(merged, PROFILES[profileName].Import)
+    const encodedValue = encodeURIComponent(JSON.stringify(merged))
     await kuboApiPost(ipfsd, `/api/v0/config?arg=Import&arg=${encodedValue}&json=true`)
 
     // chcid re-hashes the MFS root under the new CID version. It takes
@@ -181,11 +149,11 @@ module.exports = async function setupCidProfile () {
     const ipfsd = await getIpfsd(true)
     if (!ipfsd) return
 
-    // The user may edit ~/.ipfs/config directly between runs, so the stored
-    // cidProfile is a hint rather than the source of truth. Read the live
-    // Import.* section, classify it, and update the store on drift.
-    // CONFIG_UPDATED then nudges the tray to rebuild so the radio reflects
-    // reality (including flipping to the read-only "Manual" item).
+    // The user may edit ~/.ipfs/config directly between runs, so the
+    // stored cidProfile is a hint, not the source of truth. Read the live
+    // Import.* section, classify, and update the store on drift.
+    // CONFIG_UPDATED then triggers a tray rebuild so the radio matches the
+    // live config (flipping to "Manual" when needed).
     try {
       const importSection = await fetchImportConfig(ipfsd)
       const detected = detectCurrentProfile(importSection)

--- a/src/common/kubo-rpc.js
+++ b/src/common/kubo-rpc.js
@@ -1,0 +1,37 @@
+const http = require('http')
+
+// TODO: drop this raw HTTP helper once the project switches to
+// kubo-rpc-client. The client exposes config.get / config.set / files.chcid
+// and handles auth headers, query encoding, and IPv6 for us.
+function kuboApiPost (ipfsd, apiPath) {
+  return new Promise((resolve, reject) => {
+    const { address, port } = ipfsd.apiAddr.nodeAddress()
+
+    const req = http.request({
+      method: 'POST',
+      hostname: address,
+      port,
+      path: apiPath,
+      timeout: 30000
+    }, (res) => {
+      let data = ''
+      res.on('data', chunk => { data += chunk })
+      res.on('end', () => {
+        if (res.statusCode === 200) {
+          resolve(data)
+        } else {
+          reject(new Error(`kubo API ${apiPath} returned status ${res.statusCode}: ${data}`))
+        }
+      })
+    })
+
+    req.on('error', reject)
+    req.on('timeout', () => {
+      req.destroy()
+      reject(new Error(`kubo API ${apiPath} request timed out`))
+    })
+    req.end()
+  })
+}
+
+module.exports = { kuboApiPost }

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ const setupAutoUpdater = require('./auto-updater')
 const setupTray = require('./tray')
 const setupAnalytics = require('./analytics')
 const setupCidProfile = require('./cid-profile')
+const setupProvideStrategy = require('./provide-strategy')
 const setupSecondInstance = require('./second-instance')
 const { analyticsKeys } = require('./analytics/keys')
 const handleError = require('./handleError')
@@ -82,6 +83,7 @@ async function run () {
       setupPubsub(),
       setupNamesysPubsub(),
       setupCidProfile(),
+      setupProvideStrategy(),
       setupSecondInstance(),
       // Setup global shortcuts
       setupTakeScreenshot()

--- a/src/provide-strategy.js
+++ b/src/provide-strategy.js
@@ -1,0 +1,179 @@
+const { ipcMain } = require('electron')
+const store = require('./common/store')
+const logger = require('./common/logger')
+const ipcMainEvents = require('./common/ipc-main-events')
+const { kuboApiPost } = require('./common/kubo-rpc')
+const { STATUS } = require('./daemon/consts')
+const getCtx = require('./context')
+
+// Override kubo's default Provide.Strategy ("all", which announces every
+// stored block) with a smaller subset suited to desktop nodes. The named
+// strategies below use kubo's "+unique" bloom-deduplicated modes:
+// "pinned+mfs+unique" is kubo's recommended desktop default and announces
+// pins plus MFS; "pinned+unique" announces pins only. See:
+// https://github.com/ipfs/kubo/blob/master/docs/config.md#providestrategy
+//
+// Each named strategy also writes an explicit Import.FastProvide* triple:
+// - FastProvideRoot=true announces every newly-added or pinned root
+//   immediately. Kubo's current default; set explicitly so a future kubo
+//   change cannot silently weaken the guarantee.
+// - FastProvideDAG=true walks the full DAG on add or pin, so a non-"all"
+//   strategy still announces new content right away instead of waiting
+//   for the next reprovide cycle.
+// - FastProvideWait=false keeps add and pin commands non-blocking; the
+//   provide runs in the background.
+const FAST_PROVIDE_TRIPLE = {
+  FastProvideRoot: true,
+  FastProvideDAG: true,
+  FastProvideWait: false
+}
+
+const STRATEGIES = {
+  'pinned+mfs+unique': {
+    Strategy: 'pinned+mfs+unique',
+    Import: { ...FAST_PROVIDE_TRIPLE }
+  },
+  'pinned+unique': {
+    Strategy: 'pinned+unique',
+    Import: { ...FAST_PROVIDE_TRIPLE }
+  }
+}
+
+// Union of Import.* keys provide-strategy owns. Detection projects Import
+// to these keys only, so unrelated Import.* fields (cid-profile settings,
+// future kubo schema additions) cannot trigger 'manual'.
+const STRATEGY_IMPORT_KEYS = new Set(
+  Object.values(STRATEGIES).flatMap(s => Object.keys(s.Import))
+)
+
+async function fetchProvideStrategy (ipfsd) {
+  const raw = await kuboApiPost(ipfsd, '/api/v0/config?arg=Provide.Strategy')
+  const parsed = JSON.parse(raw)
+  // Kubo returns null/empty for an unset optionalString.
+  return parsed.Value || ''
+}
+
+async function fetchImportConfig (ipfsd) {
+  const raw = await kuboApiPost(ipfsd, '/api/v0/config?arg=Import')
+  const parsed = JSON.parse(raw)
+  return parsed.Value || {}
+}
+
+function matchesImport (knownImport, profileImport) {
+  for (const key of Object.keys(profileImport)) {
+    if (knownImport[key] !== profileImport[key]) return false
+  }
+  return true
+}
+
+function detectCurrentStrategy (provideStrategy, importSection) {
+  // Project Import to provide-strategy keys; unrelated keys stay invisible
+  // so they cannot flip the state to 'manual' on their own.
+  const known = {}
+  for (const key of STRATEGY_IMPORT_KEYS) {
+    known[key] = importSection?.[key] ?? null
+  }
+
+  const strategyEmpty = !provideStrategy
+  const fastProvideAllNull = Object.values(known).every(v => v === null)
+
+  // Strategy unset and every FastProvide* null: pristine, just-cleared, or
+  // only unrelated fields edited. Show "Default".
+  if (strategyEmpty && fastProvideAllNull) return 'default'
+
+  for (const [name, profile] of Object.entries(STRATEGIES)) {
+    if (provideStrategy === profile.Strategy && matchesImport(known, profile.Import)) {
+      return name
+    }
+  }
+
+  // The live config matches no known profile. Show read-only "Manual" so
+  // a tray click cannot overwrite the user's hand-tuned settings.
+  return 'manual'
+}
+
+async function applyProvideStrategy (ipfsd, name) {
+  let step = 'init'
+  try {
+    // Write Provide.Strategy as an individual field to leave the rest of
+    // the Provide section (DHT tuning, BloomFPRate) untouched.
+    step = 'provide write'
+    const strategyValue = name === 'default' ? null : STRATEGIES[name].Strategy
+    const encodedStrategy = encodeURIComponent(JSON.stringify(strategyValue))
+    await kuboApiPost(ipfsd, `/api/v0/config?arg=Provide.Strategy&arg=${encodedStrategy}&json=true`)
+
+    // Read-merge-write Import so we touch only the FastProvide* triple and
+    // preserve foreign Import.* keys (cid-profile's UnixFS settings,
+    // hand-set values, future kubo additions). "Default" nulls our keys,
+    // leaving Kubo to apply its built-ins.
+    step = 'import write'
+    const existing = await fetchImportConfig(ipfsd)
+    const merged = { ...existing }
+    for (const key of STRATEGY_IMPORT_KEYS) merged[key] = null
+    if (name !== 'default') Object.assign(merged, STRATEGIES[name].Import)
+    const encodedImport = encodeURIComponent(JSON.stringify(merged))
+    await kuboApiPost(ipfsd, `/api/v0/config?arg=Import&arg=${encodedImport}&json=true`)
+
+    // Persist, then restart the daemon. Kubo clears the provide queue on a
+    // Provide.Strategy change at startup, so the new strategy takes effect
+    // cleanly without an explicit `ipfs provide clear`.
+    step = 'persist'
+    await store.safeSet('provideStrategy', name, () => {
+      ipcMain.emit(ipcMainEvents.IPFS_CONFIG_CHANGED)
+    })
+
+    logger.info(`[provide-strategy] applied '${name}'`)
+  } catch (err) {
+    logger.error(`[provide-strategy] ${step} failed for '${name}': ${err.message}`)
+  }
+}
+
+module.exports = async function setupProvideStrategy () {
+  const getIpfsd = getCtx().getFn('getIpfsd')
+
+  ipcMain.on('provideStrategy.select', async (_, name) => {
+    if (name !== 'default' && !STRATEGIES[name]) {
+      logger.error(`[provide-strategy] unknown strategy: ${name}`)
+      return
+    }
+    const ipfsd = await getIpfsd(true)
+    if (!ipfsd) {
+      logger.error('[provide-strategy] cannot apply strategy: daemon not running')
+      return
+    }
+    await applyProvideStrategy(ipfsd, name)
+  })
+
+  ipcMain.on(ipcMainEvents.IPFSD, async (status) => {
+    if (status !== STATUS.STARTING_FINISHED) return
+
+    const ipfsd = await getIpfsd(true)
+    if (!ipfsd) return
+
+    // The user may edit ~/.ipfs/config directly between runs, so the
+    // stored provideStrategy is a hint, not the source of truth. Read the
+    // live Provide.Strategy and Import.FastProvide*, classify, and update
+    // the store on drift. CONFIG_UPDATED then triggers a tray rebuild so
+    // the radio matches the live config (flipping to "Manual" when needed).
+    try {
+      const [provideStrategy, importSection] = await Promise.all([
+        fetchProvideStrategy(ipfsd),
+        fetchImportConfig(ipfsd)
+      ])
+      const detected = detectCurrentStrategy(provideStrategy, importSection)
+      const stored = store.get('provideStrategy', 'default')
+
+      if (detected !== stored) {
+        logger.info(`[provide-strategy] reconciled '${stored}' -> '${detected}' from live config`)
+        store.safeSet('provideStrategy', detected)
+        ipcMain.emit(ipcMainEvents.CONFIG_UPDATED)
+      }
+    } catch (err) {
+      logger.error(`[provide-strategy] reconcile failed: ${err.message}`)
+    }
+  })
+
+  logger.info(`[provide-strategy] active: ${store.get('provideStrategy', 'default')}`)
+}
+
+module.exports.detectCurrentStrategy = detectCurrentStrategy

--- a/src/tray.js
+++ b/src/tray.js
@@ -20,14 +20,65 @@ const { isSupported: supportsLaunchAtLogin } = require('./auto-launch')
 const createToggler = require('./utils/create-toggler')
 const getCtx = require('./context')
 
+// "Default" lets the user opt back to implicit kubo defaults by nulling
+// our owned keys; it stays visible so the user can switch from a named
+// profile back to defaults at any time. "Manual" is the only state that
+// locks the named radios: when the live config matches no known profile,
+// disabling clicks prevents a stray selection from overwriting the user's
+// hand-tuned settings. To leave Manual, the user must edit the config
+// file directly.
+
+function buildProvideStrategySubmenu () {
+  const strategy = store.get('provideStrategy', 'default')
+  const isManual = strategy === 'manual'
+  const writable = !isManual
+
+  return [{
+    id: 'provideStrategySubmenu',
+    label: i18n.t('provideStrategy.title'),
+    submenu: [
+      {
+        id: 'provideStrategy.default',
+        label: i18n.t('provideStrategy.default'),
+        type: 'radio',
+        checked: strategy === 'default',
+        enabled: writable,
+        click: () => { ipcMain.emit('provideStrategy.select', null, 'default') }
+      },
+      {
+        id: 'provideStrategy.pinnedMfs',
+        label: i18n.t('provideStrategy.pinnedMfs'),
+        type: 'radio',
+        checked: strategy === 'pinned+mfs+unique',
+        enabled: writable,
+        click: () => { ipcMain.emit('provideStrategy.select', null, 'pinned+mfs+unique') }
+      },
+      {
+        id: 'provideStrategy.pinned',
+        label: i18n.t('provideStrategy.pinned'),
+        type: 'radio',
+        checked: strategy === 'pinned+unique',
+        enabled: writable,
+        click: () => { ipcMain.emit('provideStrategy.select', null, 'pinned+unique') }
+      },
+      {
+        // Read-only indicator visible only when the live config matches no
+        // known profile.
+        id: 'provideStrategy.manual',
+        label: i18n.t('provideStrategy.manual'),
+        type: 'radio',
+        checked: isManual,
+        enabled: false,
+        visible: isManual
+      }
+    ]
+  }]
+}
+
 function buildCidProfileSubmenu () {
   const cidProfile = store.get('cidProfile', 'default')
   const isManual = cidProfile === 'manual'
-  // "Default" means "no Import.* config"; Kubo then applies its own defaults.
-  // Show it only on a pristine setup. Once the user picks a named profile or
-  // edits the config by hand, hide "Default" so a click cannot clear the
-  // current Import.* settings.
-  const isDefault = cidProfile === 'default'
+  const writable = !isManual
 
   return [{
     id: 'cidProfileSubmenu',
@@ -37,8 +88,8 @@ function buildCidProfileSubmenu () {
         id: 'cidProfile.default',
         label: i18n.t('cidProfile.default'),
         type: 'radio',
-        checked: isDefault,
-        visible: isDefault,
+        checked: cidProfile === 'default',
+        enabled: writable,
         click: () => { ipcMain.emit('cidProfile.select', null, 'default') }
       },
       {
@@ -46,6 +97,7 @@ function buildCidProfileSubmenu () {
         label: i18n.t('cidProfile.cidv1'),
         type: 'radio',
         checked: cidProfile === 'unixfs-v1-2025',
+        enabled: writable,
         click: () => { ipcMain.emit('cidProfile.select', null, 'unixfs-v1-2025') }
       },
       {
@@ -53,12 +105,12 @@ function buildCidProfileSubmenu () {
         label: i18n.t('cidProfile.cidv0Legacy'),
         type: 'radio',
         checked: cidProfile === 'unixfs-v0-2015',
+        enabled: writable,
         click: () => { ipcMain.emit('cidProfile.select', null, 'unixfs-v0-2015') }
       },
       {
-        // Read-only indicator. Appears only when the on-disk Import.* config
-        // matches no named profile (the user edited it by hand). Stays
-        // disabled so a click cannot overwrite the manual config.
+        // Read-only indicator visible only when the live config matches no
+        // known profile.
         id: 'cidProfile.manual',
         label: i18n.t('cidProfile.manual'),
         type: 'radio',
@@ -200,7 +252,8 @@ async function buildMenu () {
         buildCheckbox(CONFIG_KEYS.EXPERIMENT_PUBSUB, 'settings.pubsub'),
         buildCheckbox(CONFIG_KEYS.EXPERIMENT_PUBSUB_NAMESYS, 'settings.namesysPubsub'),
         { type: 'separator' },
-        ...buildCidProfileSubmenu()
+        ...buildCidProfileSubmenu(),
+        ...buildProvideStrategySubmenu()
       ]
     },
     // @ts-ignore
@@ -408,12 +461,13 @@ module.exports = async function () {
     menu.getMenuItemById('openRepoDir').enabled = fs.pathExistsSync(getKuboRepositoryPath())
     menu.getMenuItemById('openKuboConfigFile').enabled = fs.pathExistsSync(path.join(getKuboRepositoryPath(), 'config'))
 
-    // CID Profile: the parent gates the whole submenu. Grey it out when the
-    // daemon is offline, since applying a profile requires HTTP RPC.
-    // buildCidProfileSubmenu picks visibility for "Default" and "Manual"
-    // from the stored profile, so nothing else needs toggling here.
+    // CID Profile and Provide Strategy share daemon gating: the parent
+    // submenu greys out when the daemon is offline, since applying either
+    // requires HTTP RPC. The build functions handle per-radio enabled
+    // state and Manual visibility, so nothing else needs toggling here.
     const isDaemonRunning = status === STATUS.STARTING_FINISHED
     menu.getMenuItemById('cidProfileSubmenu').enabled = isDaemonRunning
+    menu.getMenuItemById('provideStrategySubmenu').enabled = isDaemonRunning
 
     if (status === STATUS.STARTING_FINISHED) {
       tray.setImage(icon(on))


### PR DESCRIPTION
## Summary

Adds a **Provide Strategy** tray submenu under `Settings`, letting desktop users opt out of kubo's `all` default and announce only what they pin or keep in MFS. Polishes [CID Profile][ipip-499] labels (shipped in #3132) and removes a now-redundant `files/chcid` call made obsolete by [kubo 0.41][kubo-0.41].

[ipip-499]: https://specs.ipfs.tech/ipips/ipip-0499/
[kubo-0.41]: https://github.com/ipfs/kubo/releases/tag/v0.41.0

No change to default behavior, this is opt-in.

## Provide Strategy

Three radios under `Settings → Provide Strategy`:

| Label | `Provide.Strategy` |
|---|---|
| `All Files, Pins, and Browsing Cache (default)` | unset (kubo's `all`) |
| `Only Files and Pins` | `pinned+mfs+unique` |
| `Only Pins` | `pinned+unique` |

Each named strategy also writes `Import.FastProvideRoot=true`, `Import.FastProvideDAG=true`, `Import.FastProvideWait=false` so newly-added content announces immediately under the active strategy instead of waiting for the next reprovide cycle. See kubo docs for [`Provide.Strategy`][provide-strategy] and [`Import.FastProvide*`][fast-provide].

[provide-strategy]: https://github.com/ipfs/kubo/blob/master/docs/config.md#providestrategy
[fast-provide]: https://github.com/ipfs/kubo/blob/master/docs/config.md#importfastprovideroot

## Coexistence with CID Profile

Both modules write to `Import.*`. Detection on each side now projects `Import.*` to its own keyset before classifying, and `apply` does read-merge-write to preserve foreign keys. The `Manually edited in Kubo config` indicator surfaces only when the live config matches no known profile for that submenu. Selecting `Default` nulls only the owned keys, so users can switch back to kubo built-ins at any time.

## CID Profile fixes

- Labels: `Modern CIDv1 (unixfs-v1-2025)` / `Legacy CIDv0 (unixfs-v0-2015)` lead with non-technical descriptors; kubo profile ids stay in parens for traceability. `Default (Kubo built-ins)` replaces the bare `Default`.
- Removed the `files/chcid` call. Kubo 0.41 ([ipfs/kubo#11273][chcid-fix]) reads `Import.CidVersion` and `Import.HashFunction` at daemon startup and applies them to the MFS root `CidBuilder`; calling `chcid` on `/` now returns 500. The existing daemon restart on profile change picks up the new format on the next MFS mutation.

[chcid-fix]: https://github.com/ipfs/kubo/pull/11273

## Test plan

- [x] Pick each Provide Strategy option; confirm `~/.ipfs/config` shows the expected `Provide.Strategy` and `Import.FastProvide*` values.
- [x] Pick each CID Profile option; add a file via Files (MFS) and confirm new content uses the new CID format.
- [x] Hand-edit `Provide.Strategy` (e.g. `mfs+unique`); restart; confirm tray flips to `Manually edited in Kubo config` and the named radios are disabled.
- [x] Hand-edit one of `Import.UnixFSRawLeaves` / `CidVersion` to a non-profile value; restart; confirm CID Profile flips to `Manually edited in Kubo config` and Provide Strategy stays unaffected.
- [x] Stop daemon; confirm both submenus grey out.