### PR TITLE
chore: update stale github repo urls

### DIFF
--- a/pkgs/chocolatey/tools/chocolateyinstall.ps1
+++ b/pkgs/chocolatey/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop';
 
-$url = 'https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.13.0/IPFS-Desktop-Setup-0.13.0.exe'
+$url = 'https://github.com/ipfs/ipfs-desktop/releases/download/v0.13.0/IPFS-Desktop-Setup-0.13.0.exe'
 $checksum = 'D7979D19F99EFD38FD42BE37F4267921DDBE16EA3F85177B99C89266355E43DD'
 
 $packageArgs = @{

--- a/pkgs/chocolatey/update.mjs
+++ b/pkgs/chocolatey/update.mjs
@@ -48,7 +48,7 @@ function hashStream (stream) {
   await fs.outputFile(nuspec, nuspecContent)
 
   console.log('Downloading latest binary from:')
-  const binaryUrl = `https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v${version}/ipfs-desktop-setup-${version}-win-x64.exe`
+  const binaryUrl = `https://github.com/ipfs/ipfs-desktop/releases/download/v${version}/ipfs-desktop-setup-${version}-win-x64.exe`
   console.log(binaryUrl)
 
   console.log('Calculating sha256...')

--- a/src/app-menu.js
+++ b/src/app-menu.js
@@ -43,7 +43,7 @@ const template = [
       {
         label: 'Learn More',
         click () {
-          shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop')
+          shell.openExternal('https://github.com/ipfs/ipfs-desktop')
         }
       }
     ]

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -85,7 +85,7 @@ function setup () {
     })
 
     if (opt === 1) {
-      shell.openExternal(`https://github.com/ipfs-shipyard/ipfs-desktop/releases/v${version}`)
+      shell.openExternal(`https://github.com/ipfs/ipfs-desktop/releases/v${version}`)
     }
   })
 

--- a/src/tray.js
+++ b/src/tray.js
@@ -316,7 +316,7 @@ async function buildMenu () {
         },
         {
           label: `ipfs-desktop ${VERSION}`,
-          click: () => { shell.openExternal(`https://github.com/ipfs-shipyard/ipfs-desktop/releases/v${VERSION}`) }
+          click: () => { shell.openExternal(`https://github.com/ipfs/ipfs-desktop/releases/v${VERSION}`) }
         },
         {
           label: hasCustomBinary()
@@ -338,7 +338,7 @@ async function buildMenu () {
         { type: 'separator' },
         {
           label: i18n.t('viewOnGitHub'),
-          click: () => { shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop/blob/master/README.md') }
+          click: () => { shell.openExternal('https://github.com/ipfs/ipfs-desktop/blob/main/README.md') }
         },
         {
           label: i18n.t('helpUsTranslate'),


### PR DESCRIPTION
Two renames left stale links in code: the GitHub org (ipfs-shipyard to ipfs) and the default branch (master to main). Fixes the tray and app menus, the updater "read release notes" dialog, and the Windows chocolatey scripts.

Comments, docs, and CHANGELOG are intentionally untouched.