### PR TITLE
fix: make the kubo binary reliably available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ipfs-utils": "^9.0.10",
         "ipfsd-ctl": "10.0.6",
         "it-last": "^1.0.6",
-        "kubo": "git+https://github.com/ipfs/npm-kubo.git#fix/binary-fetching",
+        "kubo": "git+https://github.com/ipfs/npm-kubo.git#7a5e299c801ee9eae2c29d8753b76dc23b007e14",
         "multiaddr": "10.0.1",
         "multiaddr-to-uri": "8.0.0",
         "portfinder": "^1.0.32",
@@ -8035,7 +8035,8 @@
     },
     "node_modules/kubo": {
       "version": "0.42.0",
-      "resolved": "git+https://github.com/ipfs/npm-kubo.git#e5cb89bc9d10642a3ef49169f3c99c5c3d08e2b7",
+      "resolved": "git+https://github.com/ipfs/npm-kubo.git#7a5e299c801ee9eae2c29d8753b76dc23b007e14",
+      "integrity": "sha512-MgY1goKZS03WQduxkdUOOqtJzHJ7SEzjx6ZBjv6KrRYnXG+6h8zN3anKuPOTgXqm8piEnwnwwHMIKfM485zX8g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19376,8 +19377,9 @@
       }
     },
     "kubo": {
-      "version": "git+https://github.com/ipfs/npm-kubo.git#e5cb89bc9d10642a3ef49169f3c99c5c3d08e2b7",
-      "from": "kubo@git+https://github.com/ipfs/npm-kubo.git#fix/binary-fetching",
+      "version": "git+https://github.com/ipfs/npm-kubo.git#7a5e299c801ee9eae2c29d8753b76dc23b007e14",
+      "integrity": "sha512-MgY1goKZS03WQduxkdUOOqtJzHJ7SEzjx6ZBjv6KrRYnXG+6h8zN3anKuPOTgXqm8piEnwnwwHMIKfM485zX8g==",
+      "from": "kubo@git+https://github.com/ipfs/npm-kubo.git#7a5e299c801ee9eae2c29d8753b76dc23b007e14",
       "requires": {
         "cachedir": "^2.3.0",
         "got": "^11.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ipfs-utils": "^9.0.10",
         "ipfsd-ctl": "10.0.6",
         "it-last": "^1.0.6",
-        "kubo": "0.42.0",
+        "kubo": "git+https://github.com/ipfs/npm-kubo.git#fix/binary-fetching",
         "multiaddr": "10.0.1",
         "multiaddr-to-uri": "8.0.0",
         "portfinder": "^1.0.32",
@@ -8035,8 +8035,7 @@
     },
     "node_modules/kubo": {
       "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.42.0.tgz",
-      "integrity": "sha512-980G+BC9sLKJZIjaJ2hI6sWMkYP55Fo00BRcBaoIZ0uPUUuiHu7u69ZTSsWTyBA6MbkLPAWCgbCD9jh3GWN2yA==",
+      "resolved": "git+https://github.com/ipfs/npm-kubo.git#798db89616ea49c0bc918c5340bc7112f57c7ed9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19377,9 +19376,8 @@
       }
     },
     "kubo": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.42.0.tgz",
-      "integrity": "sha512-980G+BC9sLKJZIjaJ2hI6sWMkYP55Fo00BRcBaoIZ0uPUUuiHu7u69ZTSsWTyBA6MbkLPAWCgbCD9jh3GWN2yA==",
+      "version": "git+https://github.com/ipfs/npm-kubo.git#798db89616ea49c0bc918c5340bc7112f57c7ed9",
+      "from": "kubo@git+https://github.com/ipfs/npm-kubo.git#fix/binary-fetching",
       "requires": {
         "cachedir": "^2.3.0",
         "got": "^11.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8035,7 +8035,7 @@
     },
     "node_modules/kubo": {
       "version": "0.42.0",
-      "resolved": "git+https://github.com/ipfs/npm-kubo.git#798db89616ea49c0bc918c5340bc7112f57c7ed9",
+      "resolved": "git+https://github.com/ipfs/npm-kubo.git#e5cb89bc9d10642a3ef49169f3c99c5c3d08e2b7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19376,7 +19376,7 @@
       }
     },
     "kubo": {
-      "version": "git+https://github.com/ipfs/npm-kubo.git#798db89616ea49c0bc918c5340bc7112f57c7ed9",
+      "version": "git+https://github.com/ipfs/npm-kubo.git#e5cb89bc9d10642a3ef49169f3c99c5c3d08e2b7",
       "from": "kubo@git+https://github.com/ipfs/npm-kubo.git#fix/binary-fetching",
       "requires": {
         "cachedir": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ipfs-utils": "^9.0.10",
     "ipfsd-ctl": "10.0.6",
     "it-last": "^1.0.6",
-    "kubo": "0.42.0",
+    "kubo": "git+https://github.com/ipfs/npm-kubo.git#fix/binary-fetching",
     "multiaddr": "10.0.1",
     "multiaddr-to-uri": "8.0.0",
     "portfinder": "^1.0.32",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ipfs-utils": "^9.0.10",
     "ipfsd-ctl": "10.0.6",
     "it-last": "^1.0.6",
-    "kubo": "git+https://github.com/ipfs/npm-kubo.git#fix/binary-fetching",
+    "kubo": "git+https://github.com/ipfs/npm-kubo.git#7a5e299c801ee9eae2c29d8753b76dc23b007e14",
     "multiaddr": "10.0.1",
     "multiaddr-to-uri": "8.0.0",
     "portfinder": "^1.0.32",

--- a/pkgs/macos/build-universal-kubo-binary.js
+++ b/pkgs/macos/build-universal-kubo-binary.js
@@ -39,11 +39,16 @@ const execLog = (cmd) => {
   const architectures = ['amd64', 'arm64']
   for (const arch of architectures) {
     const archDir = path.join(tmpDir, `kubo-${arch}`)
+    // TODO: parked until the `kubo` dependency is bumped to the npm-kubo
+    // release that fetches from GitHub releases and accepts `releasesUrl`
+    // (ipfs/npm-kubo#83). Do not merge before that version is published and
+    // `kubo` is bumped in package.json; until then the installed kubo still
+    // expects `distUrl` (dist.ipfs.tech).
     await downloadKubo({
       version: kuboVersion,
       platform: 'darwin',
       arch: arch,
-      distUrl: 'https://dist.ipfs.tech',
+      releasesUrl: 'https://github.com/ipfs/kubo/releases',
       installPath: archDir
     })
     console.log(`→ Downloaded ${arch} version to ${archDir}`)

--- a/pkgs/macos/build-universal-kubo-binary.js
+++ b/pkgs/macos/build-universal-kubo-binary.js
@@ -39,11 +39,6 @@ const execLog = (cmd) => {
   const architectures = ['amd64', 'arm64']
   for (const arch of architectures) {
     const archDir = path.join(tmpDir, `kubo-${arch}`)
-    // TODO: parked until the `kubo` dependency is bumped to the npm-kubo
-    // release that fetches from GitHub releases and accepts `releasesUrl`
-    // (ipfs/npm-kubo#83). Do not merge before that version is published and
-    // `kubo` is bumped in package.json; until then the installed kubo still
-    // expects `distUrl` (dist.ipfs.tech).
     await downloadKubo({
       version: kuboVersion,
       platform: 'darwin',


### PR DESCRIPTION
## Problem

Two problems, both in how ipfs-desktop gets the kubo binary:

1. **It can go missing.** The binary is fetched by a `postinstall` script, so it never lands when npm skips that script (`--ignore-scripts`, pnpm, hardened CI, and the upcoming [npm v12](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/) default). The app then shows "kubo binary not found" and the daemon won't start (#3031).
2. **One source.** It only came from dist.ipfs.tech.

## Fix

Adopt the new `kubo` (ipfs/npm-kubo#83), which tackles both:

- it downloads the binary on first use, so a skipped script heals itself, and
- it fetches from [GitHub releases](https://github.com/ipfs/kubo/releases), with dist.ipfs.tech still working behind a deprecation warning.

The macOS universal build moves to GitHub too. The kubo version is unchanged; see the npm-kubo PR for details. CI tracks the branch for now and will pin a published version before merge.

- Closes #3031

## TODO before merging this

- [ ] switch from PR branch to npm-kubo  release with ipfs/npm-kubo#83