### PR TITLE
fix: kubo config defaults suited to desktop

### DIFF
--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -88,6 +88,17 @@ function writeConfigFile (ipfsd, config) {
 // kubo config to anything you prefer and IPFS Desktop will leave it alone.
 const DEFAULT_SHUTDOWN_TIMEOUT = '50s'
 
+// Which blocks the node announces to the DHT. Kubo defaults to "all", which
+// includes everything fetched while browsing, so a laptop ends up announcing
+// content the user never chose to host. Announce what they did choose: their
+// recursive pins plus the local part of MFS, which is what the Files and Pins
+// screens produce. "+unique" bloom-filters CIDs shared between pins so the
+// reprovide cycle does not walk them repeatedly.
+// This is a starting value, not a lock: set Provide.Strategy in the kubo
+// config to anything you prefer and IPFS Desktop will leave it alone.
+// https://github.com/ipfs/kubo/blob/master/docs/config.md#providestrategy
+const DEFAULT_PROVIDE_STRATEGY = 'pinned+mfs+unique'
+
 /**
  * Set default minimum and maximum of connections to maintain
  * by default. This must only be called for repositories created
@@ -105,6 +116,9 @@ function applyDefaults (ipfsd) {
   config.Swarm = config.Swarm ?? {}
   config.Swarm.DisableNatPortMap = false // uPnP
   config.Swarm.ConnMgr = config.Swarm.ConnMgr ?? {}
+
+  config.Provide = config.Provide ?? {}
+  config.Provide.Strategy = DEFAULT_PROVIDE_STRATEGY
 
   config.Discovery = config.Discovery ?? {}
   config.Discovery.MDNS = config.Discovery.MDNS ?? {}
@@ -275,6 +289,17 @@ function migrateConfig (ipfsd) {
     }
     if (config.Internal.ShutdownTimeout === undefined) {
       config.Internal.ShutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT
+      changed = true
+    }
+
+    // Announce only explicitly kept content if there is no explicit user
+    // preference. An unset Strategy means kubo's "all" was in effect, which
+    // the user never asked for. A repo old enough to still carry the removed
+    // Reprovider.Strategy is left alone: kubo's own repo migration moves that
+    // value into Provide.Strategy, and it is a preference either way.
+    if (config.Reprovider?.Strategy === undefined && config.Provide?.Strategy === undefined) {
+      config.Provide = config.Provide ?? {}
+      config.Provide.Strategy = DEFAULT_PROVIDE_STRATEGY
       changed = true
     }
   }

--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -78,6 +78,16 @@ function writeConfigFile (ipfsd, config) {
   fs.writeJsonSync(getConfigFilePath(ipfsd), config, { spaces: 2 })
 }
 
+// Caps how long kubo may spend shutting down gracefully. It has to stay
+// below the 60s deadline in ipfsd-ctl's stop(), after which the daemon is
+// SIGKILLed: reaching our own cap first means kubo logs which subsystem is
+// stuck and exits on its own terms, instead of dying without a trace.
+// Kubo's own default is 12h, sized for servers, so quitting the app would
+// otherwise always wait the full 60s on a hung subsystem.
+// This is a starting value, not a lock: set Internal.ShutdownTimeout in the
+// kubo config to anything you prefer and IPFS Desktop will leave it alone.
+const DEFAULT_SHUTDOWN_TIMEOUT = '50s'
+
 /**
  * Set default minimum and maximum of connections to maintain
  * by default. This must only be called for repositories created
@@ -102,6 +112,9 @@ function applyDefaults (ipfsd) {
 
   config.AutoTLS = config.AutoTLS ?? {}
   config.AutoTLS.Enabled = true
+
+  config.Internal = config.Internal ?? {}
+  config.Internal.ShutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT
 
   writeConfigFile(ipfsd, config)
 }
@@ -153,7 +166,7 @@ const getGatewayPort = (config) => getHttpPort(config.Addresses.Gateway)
  */
 function migrateConfig (ipfsd) {
   // Bump revision number when new migration rule is added
-  const REVISION = 6
+  const REVISION = 7
   const REVISION_KEY = 'daemonConfigRevision'
   const CURRENT_REVISION = store.get(REVISION_KEY, 0)
 
@@ -250,6 +263,18 @@ function migrateConfig (ipfsd) {
     }
     if (config.AutoTLS.Enabled === undefined) {
       config.AutoTLS.Enabled = true
+      changed = true
+    }
+  }
+
+  if (CURRENT_REVISION < 7) {
+    // Cap graceful shutdown if there is no explicit user preference
+    if (config.Internal === undefined) {
+      config.Internal = {}
+      changed = true
+    }
+    if (config.Internal.ShutdownTimeout === undefined) {
+      config.Internal.ShutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT
       changed = true
     }
   }


### PR DESCRIPTION
## Problem

Two kubo defaults are sized for servers and land badly on a laptop.

`Provide.Strategy` defaults to `all`, so the node announces every block in its datastore. That includes anything pulled in just by browsing, so users tell the network they host content they never chose to keep, and pay the reprovide cost for it on every cycle.

`Internal.ShutdownTimeout` defaults to 12 hours. ipfsd-ctl SIGKILLs the daemon 60 seconds after `stop()`, so a stuck subsystem meant quitting the app always waited the full minute and then died without leaving a clue why.

## Fix

- Announce only what the user asked for: content they explicitly pinned, plus what they imported into MFS through the Files screen (`pinned+mfs+unique`). See [`Provide.Strategy`](https://github.com/ipfs/kubo/blob/master/docs/config.md#providestrategy).
- Cap graceful shutdown at 50s, comfortably under ipfsd-ctl's 60s kill, so kubo can log which subsystem is stuck and exit on its own terms.

Both are starting values, not locks. New repos get them from `applyDefaults`, existing ones from `migrateConfig` revision 7, and in both cases a value the user already set is left alone. A repo old enough to still carry the removed `Reprovider.Strategy` is skipped entirely, so kubo's own repo migration can move that preference across untouched.