### PR TITLE
feat: new repos import as CIDv1 from IPIP-499

### DIFF
--- a/src/cid-profile.js
+++ b/src/cid-profile.js
@@ -6,6 +6,8 @@ const { kuboApiPost } = require('./common/kubo-rpc')
 const { STATUS } = require('./daemon/consts')
 const getCtx = require('./context')
 
+// IPIP-499 import profiles, mirroring the definitions kubo ships in
+// config/profile.go. https://specs.ipfs.tech/ipips/ipip-0499/
 const PROFILES = {
   'unixfs-v1-2025': {
     Import: {
@@ -37,6 +39,12 @@ const PROFILES = {
   }
 }
 
+// What a repo created by IPFS Desktop imports as. Kubo's `ipfs init` still
+// writes no Import.* and so falls back to CIDv0; this picks the modern
+// profile for new users without waiting on ipfs/kubo#8185. Existing repos
+// keep whatever they have, and anyone can switch from the tray menu.
+const DEFAULT_CID_PROFILE = 'unixfs-v1-2025'
+
 async function fetchImportConfig (ipfsd) {
   const raw = await kuboApiPost(ipfsd, '/api/v0/config?arg=Import')
   const parsed = JSON.parse(raw)
@@ -50,6 +58,16 @@ async function fetchImportConfig (ipfsd) {
 const PROFILE_KEYS = new Set(
   Object.values(PROFILES).flatMap(p => Object.keys(p.Import))
 )
+
+// Whether a repo already expresses a CID profile opinion, no matter who set
+// it: the user by hand, or a kubo whose `ipfs init` writes Import.* itself.
+// Callers use this to stay out of the way instead of overriding that choice.
+// Scoped to PROFILE_KEYS, so unrelated Import.* fields do not count as one.
+function hasCidProfileSettings (importSection) {
+  return Object.entries(importSection ?? {}).some(
+    ([key, value]) => PROFILE_KEYS.has(key) && value !== null && value !== undefined
+  )
+}
 
 function matchesProfile (knownImport, profileImport) {
   for (const key of Object.keys(profileImport)) {
@@ -159,3 +177,6 @@ module.exports = async function setupCidProfile () {
 }
 
 module.exports.detectCurrentProfile = detectCurrentProfile
+module.exports.PROFILES = PROFILES
+module.exports.DEFAULT_CID_PROFILE = DEFAULT_CID_PROFILE
+module.exports.hasCidProfileSettings = hasCidProfileSettings

--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -7,6 +7,7 @@ const { shell } = require('electron')
 const store = require('../common/store')
 const logger = require('../common/logger')
 const dialogs = require('./dialogs')
+const { PROFILES, DEFAULT_CID_PROFILE, hasCidProfileSettings } = require('../cid-profile')
 
 /**
  * Get repository configuration file path.
@@ -129,6 +130,16 @@ function applyDefaults (ipfsd) {
 
   config.Internal = config.Internal ?? {}
   config.Internal.ShutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT
+
+  // Import as CIDv1, but only if `ipfs init` left the choice open. Kubo writes
+  // no Import.* today, so a fresh repo silently falls back to CIDv0; once kubo
+  // ships a default of its own (ipfs/kubo#8185) this steps aside rather than
+  // overriding it. Only ever for repos we just created: changing this later
+  // would change the CIDs a user's future imports produce, which is theirs to
+  // decide from the tray menu, so migrateConfig deliberately leaves it alone.
+  if (!hasCidProfileSettings(config.Import)) {
+    config.Import = { ...(config.Import ?? {}), ...PROFILES[DEFAULT_CID_PROFILE].Import }
+  }
 
   writeConfigFile(ipfsd, config)
 }


### PR DESCRIPTION
## Problem

Kubo's `ipfs init` does not write any `Import.*` settings, so a brand new repo falls back to CIDv0. Anything a new IPFS Desktop user adds gets a `Qm...` CID, which is the 2015 format. CIDv1 in base32 (`bafy.../bafk...`) is what the rest of IPFS expects now: it works on subdomain gateways, and it is what other implementations produce for the same file.

## Fix

- When IPFS Desktop creates a repo, write the `unixfs-v1-2025` import profile from [IPIP-499](https://specs.ipfs.tech/ipips/ipip-0499/). New users then get CIDv1 out of the box, and the same bytes give them the same CID as anyone else following the spec.
- Skip this if the repo already says how to import. Kubo does not set those fields today, but ipfs/kubo#8185 would, and then Desktop leaves the choice to Kubo.

Only repos we create. Changing this for an existing user would change the CIDs their future imports produce, so that stays their call through the tray menu added in #3132.