### PR TITLE
fix: robust provide strategy detection

### DIFF
--- a/src/cid-profile.js
+++ b/src/cid-profile.js
@@ -53,8 +53,8 @@ async function fetchImportConfig (ipfsd) {
 
 // Union of Import.* keys cid-profile owns. Detection projects Import to
 // these keys only, so unrelated Import.* fields (future kubo schema
-// additions, another module's keys like provide-strategy's FastProvide*)
-// cannot trigger 'manual'.
+// additions, the FastProvide* defaults from daemon/config.js) cannot
+// trigger 'manual'.
 const PROFILE_KEYS = new Set(
   Object.values(PROFILES).flatMap(p => Object.keys(p.Import))
 )
@@ -104,9 +104,9 @@ async function applyCidProfile (ipfsd, profileName) {
     // Write Import.* through the RPC API rather than the config file to
     // avoid racing with Kubo's own config writer. Read-merge-write so we
     // touch only the cid-profile keyset and preserve foreign Import.*
-    // fields (provide-strategy's FastProvide*, hand-set values, future
-    // kubo additions). "Default" nulls our keys, leaving Kubo to apply
-    // its built-ins.
+    // fields (the FastProvide* defaults, hand-set values, future kubo
+    // additions). "Default" nulls our keys, leaving Kubo to apply its
+    // built-ins.
     step = 'config write'
     const existing = await fetchImportConfig(ipfsd)
     const merged = { ...existing }

--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -100,6 +100,27 @@ const DEFAULT_SHUTDOWN_TIMEOUT = '50s'
 // https://github.com/ipfs/kubo/blob/master/docs/config.md#providestrategy
 const DEFAULT_PROVIDE_STRATEGY = 'pinned+mfs+unique'
 
+// When newly added or pinned content gets announced. Written out key by key
+// so the answer is visible in the config file and cannot shift under the
+// user when kubo changes a default.
+// - FastProvideRoot=true announces the root of an add or pin right away,
+//   which is what makes a freshly shared link resolvable. Kubo's default.
+// - FastProvideDAG=true also walks the DAG and announces the blocks under
+//   that root, instead of leaving them for the next reprovide cycle up to
+//   Provide.DHT.Interval later. Kubo turns this off by default to keep bulk
+//   imports cheap; a desktop node adds a few files at a time, so it can
+//   afford the walk and the content is fully announced right after an add.
+// - FastProvideWait=false keeps add and pin non-blocking; the announcing
+//   happens in the background.
+// Starting values, not a lock: set any Import.FastProvide* in the kubo
+// config and IPFS Desktop will leave that one alone.
+// https://github.com/ipfs/kubo/blob/master/docs/config.md#importfastprovidedag
+const DEFAULT_FAST_PROVIDE = {
+  FastProvideRoot: true,
+  FastProvideDAG: true,
+  FastProvideWait: false
+}
+
 /**
  * Set default minimum and maximum of connections to maintain
  * by default. This must only be called for repositories created
@@ -120,6 +141,7 @@ function applyDefaults (ipfsd) {
 
   config.Provide = config.Provide ?? {}
   config.Provide.Strategy = DEFAULT_PROVIDE_STRATEGY
+  config.Import = { ...(config.Import ?? {}), ...DEFAULT_FAST_PROVIDE }
 
   config.Discovery = config.Discovery ?? {}
   config.Discovery.MDNS = config.Discovery.MDNS ?? {}
@@ -191,7 +213,7 @@ const getGatewayPort = (config) => getHttpPort(config.Addresses.Gateway)
  */
 function migrateConfig (ipfsd) {
   // Bump revision number when new migration rule is added
-  const REVISION = 7
+  const REVISION = 8
   const REVISION_KEY = 'daemonConfigRevision'
   const CURRENT_REVISION = store.get(REVISION_KEY, 0)
 
@@ -312,6 +334,19 @@ function migrateConfig (ipfsd) {
       config.Provide = config.Provide ?? {}
       config.Provide.Strategy = DEFAULT_PROVIDE_STRATEGY
       changed = true
+    }
+  }
+
+  if (CURRENT_REVISION < 8) {
+    // Announce added and pinned content promptly, key by key, keeping any
+    // FastProvide* the user chose. `ipfs init` writes these as null, so null
+    // and absent both mean "no preference".
+    config.Import = config.Import ?? {}
+    for (const [key, value] of Object.entries(DEFAULT_FAST_PROVIDE)) {
+      if (config.Import[key] == null) {
+        config.Import[key] = value
+        changed = true
+      }
     }
   }
 

--- a/src/provide-strategy.js
+++ b/src/provide-strategy.js
@@ -7,44 +7,16 @@ const { STATUS } = require('./daemon/consts')
 const getCtx = require('./context')
 
 // Override kubo's default Provide.Strategy ("all", which announces every
-// stored block) with a smaller subset suited to desktop nodes. The named
-// strategies below use kubo's "+unique" bloom-deduplicated modes:
+// stored block) with a smaller subset suited to desktop nodes. Both named
+// strategies use kubo's "+unique" bloom-deduplicated modes:
 // "pinned+mfs+unique" is kubo's recommended desktop default and announces
 // pins plus MFS; "pinned+unique" announces pins only. See:
 // https://github.com/ipfs/kubo/blob/master/docs/config.md#providestrategy
 //
-// Each named strategy also writes an explicit Import.FastProvide* triple:
-// - FastProvideRoot=true announces every newly-added or pinned root
-//   immediately. Kubo's current default; set explicitly so a future kubo
-//   change cannot silently weaken the guarantee.
-// - FastProvideDAG=true walks the full DAG on add or pin, so a non-"all"
-//   strategy still announces new content right away instead of waiting
-//   for the next reprovide cycle.
-// - FastProvideWait=false keeps add and pin commands non-blocking; the
-//   provide runs in the background.
-const FAST_PROVIDE_TRIPLE = {
-  FastProvideRoot: true,
-  FastProvideDAG: true,
-  FastProvideWait: false
-}
-
-const STRATEGIES = {
-  'pinned+mfs+unique': {
-    Strategy: 'pinned+mfs+unique',
-    Import: { ...FAST_PROVIDE_TRIPLE }
-  },
-  'pinned+unique': {
-    Strategy: 'pinned+unique',
-    Import: { ...FAST_PROVIDE_TRIPLE }
-  }
-}
-
-// Union of Import.* keys provide-strategy owns. Detection projects Import
-// to these keys only, so unrelated Import.* fields (cid-profile settings,
-// future kubo schema additions) cannot trigger 'manual'.
-const STRATEGY_IMPORT_KEYS = new Set(
-  Object.values(STRATEGIES).flatMap(s => Object.keys(s.Import))
-)
+// Provide.Strategy alone decides which entry is active. The Import.* section
+// says nothing about it: FastProvide* are import-time knobs IPFS Desktop
+// writes once per repo (see daemon/config.js), not part of the strategy.
+const STRATEGIES = ['pinned+mfs+unique', 'pinned+unique']
 
 async function fetchProvideStrategy (ipfsd) {
   const raw = await kuboApiPost(ipfsd, '/api/v0/config?arg=Provide.Strategy')
@@ -53,42 +25,14 @@ async function fetchProvideStrategy (ipfsd) {
   return parsed.Value || ''
 }
 
-async function fetchImportConfig (ipfsd) {
-  const raw = await kuboApiPost(ipfsd, '/api/v0/config?arg=Import')
-  const parsed = JSON.parse(raw)
-  return parsed.Value || {}
-}
+function detectCurrentStrategy (provideStrategy) {
+  // Unset, so kubo's own built-in is in effect. Show "Default".
+  if (!provideStrategy) return 'default'
 
-function matchesImport (knownImport, profileImport) {
-  for (const key of Object.keys(profileImport)) {
-    if (knownImport[key] !== profileImport[key]) return false
-  }
-  return true
-}
+  if (STRATEGIES.includes(provideStrategy)) return provideStrategy
 
-function detectCurrentStrategy (provideStrategy, importSection) {
-  // Project Import to provide-strategy keys; unrelated keys stay invisible
-  // so they cannot flip the state to 'manual' on their own.
-  const known = {}
-  for (const key of STRATEGY_IMPORT_KEYS) {
-    known[key] = importSection?.[key] ?? null
-  }
-
-  const strategyEmpty = !provideStrategy
-  const fastProvideAllNull = Object.values(known).every(v => v === null)
-
-  // Strategy unset and every FastProvide* null: pristine, just-cleared, or
-  // only unrelated fields edited. Show "Default".
-  if (strategyEmpty && fastProvideAllNull) return 'default'
-
-  for (const [name, profile] of Object.entries(STRATEGIES)) {
-    if (provideStrategy === profile.Strategy && matchesImport(known, profile.Import)) {
-      return name
-    }
-  }
-
-  // The live config matches no known profile. Show read-only "Manual" so
-  // a tray click cannot overwrite the user's hand-tuned settings.
+  // Some other strategy, so the user picked it by hand. Show read-only
+  // "Manual" to keep a tray click from overwriting it.
   return 'manual'
 }
 
@@ -96,23 +40,12 @@ async function applyProvideStrategy (ipfsd, name) {
   let step = 'init'
   try {
     // Write Provide.Strategy as an individual field to leave the rest of
-    // the Provide section (DHT tuning, BloomFPRate) untouched.
+    // the Provide section (DHT tuning, BloomFPRate) untouched. "Default"
+    // nulls it, leaving Kubo to apply its built-in.
     step = 'provide write'
-    const strategyValue = name === 'default' ? null : STRATEGIES[name].Strategy
+    const strategyValue = name === 'default' ? null : name
     const encodedStrategy = encodeURIComponent(JSON.stringify(strategyValue))
     await kuboApiPost(ipfsd, `/api/v0/config?arg=Provide.Strategy&arg=${encodedStrategy}&json=true`)
-
-    // Read-merge-write Import so we touch only the FastProvide* triple and
-    // preserve foreign Import.* keys (cid-profile's UnixFS settings,
-    // hand-set values, future kubo additions). "Default" nulls our keys,
-    // leaving Kubo to apply its built-ins.
-    step = 'import write'
-    const existing = await fetchImportConfig(ipfsd)
-    const merged = { ...existing }
-    for (const key of STRATEGY_IMPORT_KEYS) merged[key] = null
-    if (name !== 'default') Object.assign(merged, STRATEGIES[name].Import)
-    const encodedImport = encodeURIComponent(JSON.stringify(merged))
-    await kuboApiPost(ipfsd, `/api/v0/config?arg=Import&arg=${encodedImport}&json=true`)
 
     // Persist, then restart the daemon. Kubo clears the provide queue on a
     // Provide.Strategy change at startup, so the new strategy takes effect
@@ -132,7 +65,7 @@ module.exports = async function setupProvideStrategy () {
   const getIpfsd = getCtx().getFn('getIpfsd')
 
   ipcMain.on('provideStrategy.select', async (_, name) => {
-    if (name !== 'default' && !STRATEGIES[name]) {
+    if (name !== 'default' && !STRATEGIES.includes(name)) {
       logger.error(`[provide-strategy] unknown strategy: ${name}`)
       return
     }
@@ -152,15 +85,12 @@ module.exports = async function setupProvideStrategy () {
 
     // The user may edit ~/.ipfs/config directly between runs, so the
     // stored provideStrategy is a hint, not the source of truth. Read the
-    // live Provide.Strategy and Import.FastProvide*, classify, and update
-    // the store on drift. CONFIG_UPDATED then triggers a tray rebuild so
-    // the radio matches the live config (flipping to "Manual" when needed).
+    // live Provide.Strategy, classify, and update the store on drift.
+    // CONFIG_UPDATED then triggers a tray rebuild so the radio matches the
+    // live config (flipping to "Manual" when needed).
     try {
-      const [provideStrategy, importSection] = await Promise.all([
-        fetchProvideStrategy(ipfsd),
-        fetchImportConfig(ipfsd)
-      ])
-      const detected = detectCurrentStrategy(provideStrategy, importSection)
+      const provideStrategy = await fetchProvideStrategy(ipfsd)
+      const detected = detectCurrentStrategy(provideStrategy)
       const stored = store.get('provideStrategy', 'default')
 
       if (detected !== stored) {

--- a/test/unit/daemon-config.spec.js
+++ b/test/unit/daemon-config.spec.js
@@ -1,0 +1,145 @@
+const { join } = require('path')
+const { test, expect } = require('@playwright/test')
+
+const fs = require('fs-extra')
+const tmp = require('tmp')
+const proxyquire = require('proxyquire').noCallThru()
+
+const mockLogger = require('./mocks/logger')
+const { makeRepository } = require('./../e2e/utils/ipfsd')
+const { detectCurrentStrategy } = require('../../src/provide-strategy')
+const { detectCurrentProfile } = require('../../src/cid-profile')
+
+if (process.env.CI === 'true') test.setTimeout(120000) // slow ci
+
+// migrateConfig persists the revision it reached, so it runs against a stub
+// instead of the real store: the developer's own daemonConfigRevision would
+// otherwise make every run after the first a no-op.
+function loadMigrateConfig (revision) {
+  const values = new Map()
+  if (revision !== undefined) values.set('daemonConfigRevision', revision)
+
+  const { migrateConfig } = proxyquire('../../src/daemon/config', {
+    '../common/store': {
+      get: (key, fallback) => values.has(key) ? values.get(key) : fallback,
+      set: (key, value) => values.set(key, value),
+      safeSet: (key, value) => values.set(key, value)
+    },
+    '../common/logger': mockLogger()
+  })
+
+  return { migrateConfig, values }
+}
+
+// tmp drops its directories at exit only once someone arms graceful cleanup,
+// so hold on to the callbacks and remove them by hand.
+const tmpRepos = []
+
+// Stands in for the ipfsd controller: both config writers only read .path.
+function repoWithConfig (config) {
+  const { name: path, removeCallback } = tmp.dirSync({ prefix: 'tmp_IPFS_PATH_', unsafeCleanup: true })
+  tmpRepos.push(removeCallback)
+  fs.writeJsonSync(join(path, 'config'), config, { spaces: 2 })
+  return { path }
+}
+
+const readConfig = (ipfsd) => fs.readJsonSync(join(ipfsd.path, 'config'))
+
+// An IPFS Desktop repo from before the Provide defaults landed. Addresses are
+// there because the older migrations read the gateway port.
+const legacyConfig = () => ({
+  Addresses: {
+    API: '/ip4/127.0.0.1/tcp/5001',
+    Gateway: '/ip4/127.0.0.1/tcp/8080'
+  },
+  API: { HTTPHeaders: {} },
+  Discovery: { MDNS: { Enabled: true } },
+  Swarm: { ConnMgr: {} }
+})
+
+test.describe('applyDefaults', function () {
+  let ipfsd, config
+
+  test.beforeAll(async () => {
+    // Runs `ipfs init` and then applyDefaults, the pair src/daemon/daemon.js
+    // runs for a repo IPFS Desktop creates. No daemon needed.
+    const repo = await makeRepository({ start: false })
+    ipfsd = repo.ipfsd
+    config = fs.readJsonSync(repo.configPath)
+  })
+
+  test.afterAll(async () => {
+    if (ipfsd) await ipfsd.stop()
+  })
+
+  // What we write has to classify as a named entry. Anything else reconciles
+  // to 'manual' on first start, and the tray then renders the submenu
+  // read-only for a config IPFS Desktop wrote itself.
+  test('writes a provide strategy the tray can name', () => {
+    expect(detectCurrentStrategy(config.Provide.Strategy)).toEqual('pinned+mfs+unique')
+  })
+
+  test('writes a cid profile the tray can name', () => {
+    expect(detectCurrentProfile(config.Import)).toEqual('unixfs-v1-2025')
+  })
+
+  test('writes the fast provide preferences explicitly', () => {
+    expect(config.Import.FastProvideRoot).toEqual(true)
+    expect(config.Import.FastProvideDAG).toEqual(true)
+    expect(config.Import.FastProvideWait).toEqual(false)
+  })
+})
+
+test.describe('migrateConfig', function () {
+  test.afterAll(() => {
+    tmpRepos.forEach(remove => remove())
+  })
+
+  test('gives an old repo the provide defaults', () => {
+    const { migrateConfig, values } = loadMigrateConfig()
+    const ipfsd = repoWithConfig(legacyConfig())
+
+    migrateConfig(ipfsd)
+
+    const config = readConfig(ipfsd)
+    expect(detectCurrentStrategy(config.Provide.Strategy)).toEqual('pinned+mfs+unique')
+    expect(config.Import.FastProvideRoot).toEqual(true)
+    expect(config.Import.FastProvideDAG).toEqual(true)
+    expect(config.Import.FastProvideWait).toEqual(false)
+    expect(values.get('daemonConfigRevision')).toEqual(8)
+  })
+
+  // Revision 7 set Provide.Strategy on its own. `ipfs init` leaves the
+  // FastProvide keys as nulls, which is the shape the fill-in has to see
+  // through.
+  test('fills in what revision 7 left out', () => {
+    const { migrateConfig } = loadMigrateConfig(7)
+    const ipfsd = repoWithConfig({
+      ...legacyConfig(),
+      Provide: { Strategy: 'pinned+mfs+unique' },
+      Import: { CidVersion: null, FastProvideRoot: null, FastProvideDAG: null, FastProvideWait: null }
+    })
+
+    migrateConfig(ipfsd)
+
+    const config = readConfig(ipfsd)
+    expect(config.Import.FastProvideRoot).toEqual(true)
+    expect(config.Import.FastProvideDAG).toEqual(true)
+    expect(config.Import.FastProvideWait).toEqual(false)
+  })
+
+  test('keeps a fast provide preference the user set', () => {
+    const { migrateConfig } = loadMigrateConfig(7)
+    const ipfsd = repoWithConfig({
+      ...legacyConfig(),
+      Import: { FastProvideDAG: false }
+    })
+
+    migrateConfig(ipfsd)
+
+    const config = readConfig(ipfsd)
+    expect(config.Import.FastProvideDAG).toEqual(false)
+    expect(config.Import.FastProvideRoot).toEqual(true)
+    expect(config.Import.FastProvideWait).toEqual(false)
+  })
+})

--- a/test/unit/provide-strategy.spec.js
+++ b/test/unit/provide-strategy.spec.js
@@ -1,0 +1,21 @@
+const { test, expect } = require('@playwright/test')
+
+const { detectCurrentStrategy } = require('../../src/provide-strategy')
+
+test.describe('detectCurrentStrategy', function () {
+  test('reads an unset strategy as the kubo default', () => {
+    expect(detectCurrentStrategy('')).toEqual('default')
+  })
+
+  test('names a strategy IPFS Desktop offers', () => {
+    expect(detectCurrentStrategy('pinned+mfs+unique')).toEqual('pinned+mfs+unique')
+    expect(detectCurrentStrategy('pinned+unique')).toEqual('pinned+unique')
+  })
+
+  // Anything else the user picked themselves. The tray shows it read-only so
+  // a click cannot overwrite it.
+  test('leaves a hand-set strategy alone', () => {
+    expect(detectCurrentStrategy('all')).toEqual('manual')
+    expect(detectCurrentStrategy('pinned')).toEqual('manual')
+  })
+})


### PR DESCRIPTION
## Problem

Quick follow-up to #3194, making the config handling around provide settings more robust. `Provide.Strategy` and `Import.FastProvide*` were treated as one setting, so a config carrying the strategy but not the FastProvide keys read as hand-tuned, and the tray showed Provide Strategy as a read-only "Manual". A repo IPFS Desktop sets up itself lands in exactly that state.

## Fix

- detection reads `Provide.Strategy` alone. `FastProvide*` are kubo import knobs, not part of the strategy or of IPIP-499
- they become plain repo defaults: written for new repos, and filled in key by key by migration revision 8 where the user has no preference
- added and pinned content now has the blocks under its root announced right away, not at the next reprovide cycle. The why sits in `DEFAULT_FAST_PROVIDE` in `src/daemon/config.js`

A strategy set by hand still shows read-only "Manual", which is what that state is for.