### PR TITLE
fix: avoid duplicate daemon start during startup

### DIFF
--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -37,7 +37,19 @@ async function setupDaemon () {
     return status
   }
 
-  const startIpfs = async () => {
+  // Daemon transitions run one at a time. start and stop read `ipfsd` to
+  // decide what to do, and it only tells the truth between transitions:
+  // mid-start it is still null, so a second start would spawn a Kubo that
+  // races the first for the repo lock.
+  let transition = Promise.resolve()
+  const serialize = (fn) => () => {
+    const result = transition.then(fn)
+    // a failed transition must not reject or stall the ones queued behind it
+    transition = result.catch(() => {})
+    return result
+  }
+
+  const start = async () => {
     if (ipfsd) {
       return
     }
@@ -71,7 +83,7 @@ async function setupDaemon () {
     updateStatus(STATUS.STARTING_FINISHED, res.id)
   }
 
-  const stopIpfs = async () => {
+  const stop = async () => {
     if (!ipfsd) {
       return
     }
@@ -98,10 +110,15 @@ async function setupDaemon () {
     }
   }
 
-  const restartIpfs = async () => {
-    await stopIpfs()
-    await startIpfs()
+  const restart = async () => {
+    await stop()
+    await start()
   }
+
+  const startIpfs = serialize(start)
+  const stopIpfs = serialize(stop)
+  const restartIpfs = serialize(restart)
+
   getCtx().setProp('startIpfs', runAndStatus(startIpfs))
   getCtx().setProp('stopIpfs', runAndStatus(stopIpfs))
   getCtx().setProp('restartIpfs', runAndStatus(restartIpfs))

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,14 @@ async function run () {
   }
 
   try {
+    // These initializers may normalize stored daemon flags and emit a restart.
+    // Run them before setupDaemon installs its restart listener.
+    await Promise.all([
+      setupAutoGc(),
+      setupPubsub(),
+      setupNamesysPubsub()
+    ])
+
     await Promise.all([
       createSplashScreen(),
       setupDaemon(), // ctx.getIpfsd, startIpfs, stopIpfs, restartIpfs
@@ -79,9 +87,6 @@ async function run () {
       setupTray(), // ctx.tray
       setupArgvFilesHandler(),
       setupAutoLaunch(),
-      setupAutoGc(),
-      setupPubsub(),
-      setupNamesysPubsub(),
       setupCidProfile(),
       setupProvideStrategy(),
       setupSecondInstance(),

--- a/src/index.js
+++ b/src/index.js
@@ -67,17 +67,21 @@ async function run () {
   }
 
   try {
-    // These initializers may normalize stored daemon flags and emit a restart.
-    // Run them before setupDaemon installs its restart listener.
-    await Promise.all([
+    // Put the splash window up before anything else touches the store.
+    const splashReady = createSplashScreen()
+
+    // These normalize the stored daemon flags and emit IPFS_CONFIG_CHANGED
+    // when they do. Start the daemon only once they settle, or the restart
+    // lands mid-start and a second Kubo races the first for the repo lock.
+    const daemonFlagsReady = Promise.all([
       setupAutoGc(),
       setupPubsub(),
       setupNamesysPubsub()
     ])
 
     await Promise.all([
-      createSplashScreen(),
-      setupDaemon(), // ctx.getIpfsd, startIpfs, stopIpfs, restartIpfs
+      splashReady,
+      daemonFlagsReady.then(() => setupDaemon()), // ctx.getIpfsd, startIpfs, stopIpfs, restartIpfs
       setupAnalytics(), // ctx.countlyDeviceId
       setupI18n(),
       setupAppMenu(),

--- a/src/splash/create-splash-screen.js
+++ b/src/splash/create-splash-screen.js
@@ -11,25 +11,30 @@ const path = require('node:path')
 
 module.exports = async function createSplashScreen () {
   const ctx = getCtx()
-  const splashScreen = new BrowserWindow({
-    title: 'IPFS Desktop splash screen',
-    width: 250,
-    height: 275,
-    transparent: true,
-    frame: false,
-    alwaysOnTop: true,
-    show: false
-  })
+  let splashScreen = null
 
   try {
+    splashScreen = new BrowserWindow({
+      title: 'IPFS Desktop splash screen',
+      width: 250,
+      height: 275,
+      transparent: true,
+      frame: false,
+      alwaysOnTop: true,
+      show: false
+    })
+
     await splashScreen.loadFile(path.join(__dirname, '../../assets/pages/splash.html'))
+    splashScreen.center()
   } catch (err) {
-    logger.error('[splashScreen] loadFile failed')
+    logger.error('[splashScreen] could not create splash screen')
     logger.error(err)
-    return
+    if (splashScreen) splashScreen.destroy()
+    splashScreen = null
   }
 
-  splashScreen.center()
-
+  // Always publish, even on failure. setupWebUI and the error path in index.js
+  // await this prop, and an unset one never resolves, so skipping it here
+  // stalls startup instead of losing a splash screen.
   ctx.setProp('splashScreen', splashScreen)
 }

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -325,8 +325,11 @@ module.exports = async function () {
   })
 
   const launchWebUI = ctx.getFn('launchWebUI')
+  // null when the splash window could not be created, so carry on without it.
   const splashScreen = await ctx.getProp('splashScreen')
-  if (openWebUiAtLaunch) {
+  if (!splashScreen) {
+    logger.info('[web ui] no splash screen to show')
+  } else if (openWebUiAtLaunch) {
     // we're supposed to show the window on startup, display the splash screen
     splashScreen.show()
   } else {
@@ -352,7 +355,7 @@ module.exports = async function () {
       startupRoutePending = false
     }
     try {
-      splashScreen.destroy()
+      splashScreen?.destroy()
     } catch (err) {
       logger.error('[web ui] failed to hide splash screen')
       logger.error(err)

--- a/test/unit/daemon-reentrancy.spec.js
+++ b/test/unit/daemon-reentrancy.spec.js
@@ -1,0 +1,115 @@
+const { EventEmitter } = require('events')
+const { test, expect } = require('@playwright/test')
+const ipcMainEvents = require('../../src/common/ipc-main-events')
+
+const proxyquire = require('proxyquire')
+  .noCallThru()
+  .noPreserveCache()
+
+function deferred () {
+  let release
+  const promise = new Promise(resolve => { release = resolve })
+  return { promise, resolve: release }
+}
+
+function setup () {
+  const noop = () => {}
+  const ipcMain = new EventEmitter()
+  const starts = []
+  const stops = []
+  let inFlight = 0
+  let peak = 0
+
+  // Hands back one gate per start so the test can hold a daemon mid-launch.
+  const createDaemon = async () => {
+    const gate = deferred()
+    starts.push(gate)
+    inFlight++
+    peak = Math.max(peak, inFlight)
+    try {
+      await gate.promise
+      return {
+        err: null,
+        id: `peer-${starts.length}`,
+        ipfsd: {
+          path: '/repo',
+          stop: async () => {
+            const stopGate = deferred()
+            stops.push(stopGate)
+            await stopGate.promise
+          }
+        }
+      }
+    } finally {
+      inFlight--
+    }
+  }
+
+  const setupDaemon = proxyquire('../../src/daemon/index', {
+    electron: { app: { on: noop }, ipcMain },
+    'fs-extra': { pathExistsSync: () => true },
+    '../dialogs': { ipfsNotRunningDialog: async () => {} },
+    '../common/store': { get: () => ({ path: '/repo', flags: [] }), safeSet: noop },
+    '../common/logger': {
+      start: () => ({ end: noop, fail: noop }),
+      info: noop,
+      error: noop
+    },
+    './daemon': createDaemon,
+    '../context': () => ({ setProp: noop })
+  })
+
+  return { setupDaemon, ipcMain, starts, stops, peak: () => peak }
+}
+
+const settle = () => new Promise(resolve => setImmediate(resolve))
+
+test.describe('Daemon transitions', () => {
+  test('a config change mid-start does not launch a second daemon', async () => {
+    const { setupDaemon, ipcMain, starts, stops, peak } = setup()
+
+    const ready = setupDaemon()
+    await settle()
+    expect(starts.length).toEqual(1)
+
+    // The repo lock is held by a Kubo that has not reported back yet, so this
+    // restart must not spawn another one alongside it.
+    ipcMain.emit(ipcMainEvents.IPFS_CONFIG_CHANGED)
+    await settle()
+    expect(starts.length).toEqual(1)
+    expect(peak()).toEqual(1)
+
+    starts[0].resolve()
+    await ready
+    await settle()
+
+    // The restart still happens, just afterwards: stop the first, start again.
+    expect(stops.length).toEqual(1)
+    stops[0].resolve()
+    await settle()
+    expect(starts.length).toEqual(2)
+    expect(peak()).toEqual(1)
+  })
+
+  test('overlapping restarts never run two daemons at once', async () => {
+    const { setupDaemon, ipcMain, starts, stops, peak } = setup()
+
+    const ready = setupDaemon()
+    await settle()
+    starts[0].resolve()
+    await ready
+
+    ipcMain.emit(ipcMainEvents.IPFS_CONFIG_CHANGED)
+    ipcMain.emit(ipcMainEvents.IPFS_CONFIG_CHANGED)
+    await settle()
+
+    // Drain whatever the restarts queued up, one transition at a time.
+    for (let i = 0; i < 8; i++) {
+      stops.filter(g => !g.done).forEach(g => { g.done = true; g.resolve() })
+      starts.filter(g => !g.done).forEach(g => { g.done = true; g.resolve() })
+      await settle()
+    }
+
+    expect(peak()).toEqual(1)
+  })
+})

--- a/test/unit/splash-screen.spec.js
+++ b/test/unit/splash-screen.spec.js
@@ -1,0 +1,56 @@
+const sinon = require('sinon')
+const { test, expect } = require('@playwright/test')
+
+const proxyquire = require('proxyquire')
+  .noCallThru()
+  .noPreserveCache()
+
+function setup ({ construct, loadFile }) {
+  const ctx = { setProp: sinon.spy() }
+  const window = {
+    loadFile: loadFile ?? sinon.stub().resolves(),
+    center: sinon.spy(),
+    destroy: sinon.spy()
+  }
+  const createSplashScreen = proxyquire('../../src/splash/create-splash-screen', {
+    electron: {
+      BrowserWindow: construct ?? sinon.stub().returns(window)
+    },
+    '../context': () => ctx,
+    '../common/logger': { error: sinon.spy(), info: sinon.spy() }
+  })
+
+  return { createSplashScreen, ctx, window }
+}
+
+test.describe('Splash screen', () => {
+  test('publishes the window once it loaded', async () => {
+    const { createSplashScreen, ctx, window } = setup({})
+
+    await createSplashScreen()
+
+    expect(window.center.callCount).toEqual(1)
+    expect(ctx.setProp.calledOnceWith('splashScreen', window)).toBe(true)
+  })
+
+  test('publishes null when the page fails to load', async () => {
+    const loadFile = sinon.stub().rejects(new Error('ENOENT'))
+    const { createSplashScreen, ctx, window } = setup({ loadFile })
+
+    await createSplashScreen()
+
+    // Anything awaiting the prop (setupWebUI, the error path in index.js)
+    // blocks until it is set, so a failure has to publish too.
+    expect(ctx.setProp.calledOnceWith('splashScreen', null)).toBe(true)
+    expect(window.destroy.callCount).toEqual(1)
+  })
+
+  test('publishes null when the window cannot be created', async () => {
+    const construct = sinon.stub().throws(new Error('no display'))
+    const { createSplashScreen, ctx } = setup({ construct })
+
+    await createSplashScreen()
+
+    expect(ctx.setProp.calledOnceWith('splashScreen', null)).toBe(true)
+  })
+})

--- a/test/unit/startup.spec.js
+++ b/test/unit/startup.spec.js
@@ -1,0 +1,96 @@
+const proxyquire = require('proxyquire').noCallThru()
+const { test, expect } = require('@playwright/test')
+
+function deferred () {
+  let release
+  const promise = new Promise(resolve => {
+    release = resolve
+  })
+  return { promise, resolve: release }
+}
+
+test('configures daemon flags before starting the daemon', async () => {
+  const autoGc = deferred()
+  const pubsub = deferred()
+  const namesysPubsub = deferred()
+  const finished = deferred()
+  const calls = []
+  const handleError = () => {}
+  const noop = () => {}
+  const asyncNoop = async () => {}
+  const app = {
+    setPath: noop,
+    setAppUserModelId: noop,
+    requestSingleInstanceLock: () => true,
+    on: noop,
+    whenReady: asyncNoop
+  }
+  const webui = {
+    webContents: {
+      isLoading: () => false
+    }
+  }
+  const gatedSetup = (name, gate) => async () => {
+    calls.push(`${name}:start`)
+    await gate.promise
+    calls.push(`${name}:done`)
+  }
+
+  try {
+    proxyquire('../../src/index', {
+      './metrics/appStart': {
+        registerAppStartTime: noop,
+        getSecondsSinceAppStart: () => 0
+      },
+      'v8-compile-cache': {},
+      electron: {
+        app,
+        dialog: { showErrorBox: noop }
+      },
+      './context': () => ({ getProp: async () => webui }),
+      'fix-path': noop,
+      './common/logger': {
+        addAnalyticsEvent: () => finished.resolve()
+      },
+      './protocol-handlers': noop,
+      './i18n': asyncNoop,
+      './daemon': () => calls.push('daemon'),
+      './webui': asyncNoop,
+      './auto-launch': asyncNoop,
+      './automatic-gc': gatedSetup('automatic-gc', autoGc),
+      './enable-pubsub': gatedSetup('pubsub', pubsub),
+      './enable-namesys-pubsub': gatedSetup('namesys-pubsub', namesysPubsub),
+      './take-screenshot': asyncNoop,
+      './app-menu': asyncNoop,
+      './argv-files-handler': asyncNoop,
+      './auto-updater': asyncNoop,
+      './tray': asyncNoop,
+      './analytics': asyncNoop,
+      './cid-profile': asyncNoop,
+      './provide-strategy': asyncNoop,
+      './second-instance': asyncNoop,
+      './analytics/keys': { analyticsKeys: { APP_READY: 'app-ready' } },
+      './handleError': handleError,
+      './splash/create-splash-screen': asyncNoop
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+    expect(calls).not.toContain('daemon')
+
+    autoGc.resolve()
+    pubsub.resolve()
+    namesysPubsub.resolve()
+    await finished.promise
+
+    const daemonIndex = calls.indexOf('daemon')
+    expect(daemonIndex).toBeGreaterThan(calls.indexOf('automatic-gc:done'))
+    expect(daemonIndex).toBeGreaterThan(calls.indexOf('pubsub:done'))
+    expect(daemonIndex).toBeGreaterThan(calls.indexOf('namesys-pubsub:done'))
+  } finally {
+    autoGc.resolve()
+    pubsub.resolve()
+    namesysPubsub.resolve()
+    process.removeListener('uncaughtException', handleError)
+    process.removeListener('unhandledRejection', handleError)
+  }
+})

--- a/test/unit/startup.spec.js
+++ b/test/unit/startup.spec.js
@@ -71,10 +71,13 @@ test('configures daemon flags before starting the daemon', async () => {
       './second-instance': asyncNoop,
       './analytics/keys': { analyticsKeys: { APP_READY: 'app-ready' } },
       './handleError': handleError,
-      './splash/create-splash-screen': asyncNoop
+      './splash/create-splash-screen': async () => calls.push('splash')
     })
 
     await new Promise(resolve => setImmediate(resolve))
+    // the gates are still closed, so the splash has to be up already and the
+    // daemon must not have started
+    expect(calls[0]).toBe('splash')
     expect(calls).not.toContain('daemon')
 
     autoGc.resolve()


### PR DESCRIPTION
During packaging I noticed the following issue:

`setupDaemon()` currently starts Kubo and installs the `IPFS_CONFIG_CHANGED` restart listener in parallel with `setupAutoGc()`, `setupPubsub()` and `setupNamesysPubsub()`.

Those initializers can normalize the stored daemon flags. For example, `setupAutoGc()` adds `--enable-gc` when it is missing and emits `IPFS_CONFIG_CHANGED`.

If that happens while the initial daemon start is still running, the restart handler starts a second Kubo against the same repo. One of them then fails with:

`Error: lock .../repo.lock: someone else has the lock`

Run the three daemon flag initializers before `setupDaemon()`. They can still update the stored flags, but there is no restart listener yet and the daemon starts once afterwards with the final flags.

I've added a regression test which blocks all three initializers and verifies that `setupDaemon()` does not run until they finished.
