### PR TITLE
fix: prefer distro launcher for autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ Instead, update cycle is maintained by respective communities:
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ipfs-desktop.svg)](https://repology.org/project/ipfs-desktop/versions)
 
+Packages that start IPFS Desktop through a wrapper script can set the `IPFS_DESKTOP_EXEC` environment variable to the path of that wrapper.
+The "launch at login" autostart entry then runs the wrapper instead of a command rebuilt from the Electron binary and the app path.
+The value must be a single executable path, without arguments: put any flags in the wrapper script itself.
+
 ### Install from source
 
 To install and run IPFS Desktop from source, you'll also need:

--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -32,6 +32,10 @@ function quoteDesktopEntryArg (value) {
 }
 
 function getLinuxAutostartExec () {
+  // Distro packages launch IPFS Desktop through a wrapper script and set
+  // IPFS_DESKTOP_EXEC to its path, so autostart runs the wrapper instead of a
+  // reconstructed electron command. The value is a single executable path, not
+  // a command line: flags would be quoted into the path and break the entry.
   const launcher = process.env.IPFS_DESKTOP_EXEC
   if (launcher) return quoteDesktopEntryArg(launcher)
 
@@ -55,17 +59,19 @@ async function enable () {
     return
   }
 
+  const exec = getLinuxAutostartExec()
   const desktop = `[Desktop Entry]
 Type=Application
 Version=1.0
 Name=IPFS Desktop
 Comment=IPFS Desktop Startup Script
-Exec=${getLinuxAutostartExec()}
+Exec=${exec}
 Icon=ipfs-desktop
 StartupNotify=false
 Terminal=false`
 
   await fs.outputFile(getDesktopFile(), desktop)
+  logger.info(`[launch on startup] wrote ${getDesktopFile()} with Exec=${exec}`)
 }
 
 async function disable () {

--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -32,6 +32,9 @@ function quoteDesktopEntryArg (value) {
 }
 
 function getLinuxAutostartExec () {
+  const launcher = process.env.IPFS_DESKTOP_EXEC
+  if (launcher) return quoteDesktopEntryArg(launcher)
+
   const command = [process.execPath]
 
   // Some distro packages launch as `electron <app.asar>`.

--- a/test/unit/auto-launch.spec.js
+++ b/test/unit/auto-launch.spec.js
@@ -18,14 +18,31 @@ const { quoteDesktopEntryArg, getLinuxAutostartExec } = proxyquire('../../src/au
   './dialogs': { showDialog: () => {}, recoverableErrorDialog: () => {} }
 })
 
-function withEnv ({ execPath, appPath }, fn) {
+// Every case states the whole environment it runs in, including an unset
+// IPFS_DESKTOP_EXEC, so the results do not depend on the machine running them.
+function withEnv ({ execPath, appPath, launcher }, fn) {
   const previousExecPath = process.execPath
+  const previousLauncher = process.env.IPFS_DESKTOP_EXEC
+
   process.execPath = execPath
   appState.appPath = appPath
+
+  if (launcher === undefined) {
+    delete process.env.IPFS_DESKTOP_EXEC
+  } else {
+    process.env.IPFS_DESKTOP_EXEC = launcher
+  }
+
   try {
     return fn()
   } finally {
     process.execPath = previousExecPath
+
+    if (previousLauncher === undefined) {
+      delete process.env.IPFS_DESKTOP_EXEC
+    } else {
+      process.env.IPFS_DESKTOP_EXEC = previousLauncher
+    }
   }
 }
 
@@ -63,23 +80,13 @@ test.describe('quoteDesktopEntryArg (Desktop Entry Exec= spec)', () => {
 
 test.describe('getLinuxAutostartExec', () => {
   test('prefers distro launcher from IPFS_DESKTOP_EXEC', () => {
-    const previous = process.env.IPFS_DESKTOP_EXEC
-    process.env.IPFS_DESKTOP_EXEC = '/usr/bin/ipfs-desktop'
+    const result = withEnv({
+      execPath: '/usr/lib/electron43/electron',
+      appPath: '/usr/lib/ipfs-desktop/app.asar',
+      launcher: '/usr/bin/ipfs-desktop'
+    }, getLinuxAutostartExec)
 
-    try {
-      const result = withEnv({
-        execPath: '/usr/lib/electron43/electron',
-        appPath: '/usr/lib/ipfs-desktop/app.asar'
-      }, getLinuxAutostartExec)
-
-      expect(result).toBe('"/usr/bin/ipfs-desktop"')
-    } finally {
-      if (previous === undefined) {
-        delete process.env.IPFS_DESKTOP_EXEC
-      } else {
-        process.env.IPFS_DESKTOP_EXEC = previous
-      }
-    }
+    expect(result).toBe('"/usr/bin/ipfs-desktop"')
   })
 
   test('AUR / system electron39: appends the app.asar path', () => {

--- a/test/unit/auto-launch.spec.js
+++ b/test/unit/auto-launch.spec.js
@@ -62,6 +62,26 @@ test.describe('quoteDesktopEntryArg (Desktop Entry Exec= spec)', () => {
 })
 
 test.describe('getLinuxAutostartExec', () => {
+  test('prefers distro launcher from IPFS_DESKTOP_EXEC', () => {
+    const previous = process.env.IPFS_DESKTOP_EXEC
+    process.env.IPFS_DESKTOP_EXEC = '/usr/bin/ipfs-desktop'
+
+    try {
+      const result = withEnv({
+        execPath: '/usr/lib/electron43/electron',
+        appPath: '/usr/lib/ipfs-desktop/app.asar'
+      }, getLinuxAutostartExec)
+
+      expect(result).toBe('"/usr/bin/ipfs-desktop"')
+    } finally {
+      if (previous === undefined) {
+        delete process.env.IPFS_DESKTOP_EXEC
+      } else {
+        process.env.IPFS_DESKTOP_EXEC = previous
+      }
+    }
+  })
+
   test('AUR / system electron39: appends the app.asar path', () => {
     // Real-world AUR layout: /usr/bin/ipfs-desktop wrapper execs
     // `electron39 /usr/lib/ipfs-desktop/app.asar`, so process.execPath ends up


### PR DESCRIPTION
While packaging IPFS Desktop for Arch, I noticed there is currently no way for distro packages to have the autostart function use a custom path for setting it as startup.

This PR adds `IPFS_DESKTOP_EXEC` as an optional override. If it is set, the generated desktop entry uses that launcher instead of reconstructing the command from Electron and the app path.

This allows distro packages to have their wrapper scripts placed in the autostart by ipfs-desktop.
